### PR TITLE
Fixing ghc 7.1.20101213

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -49,7 +49,7 @@ library
 
   extensions:
     CPP, DeriveDataTypeable, ForeignFunctionInterface, TypeSynonymInstances
-  if impl(ghc >= 7.0)
+  if impl(ghc >= 7.0.2)
     extensions: NondecreasingIndentation, FlexibleInstances
 
   include-dirs: include


### PR DESCRIPTION
Seems like cabal is explicitly passing -XHaskell98, so NondecreasingIndentation needs to be explicitly enabled with GHC >= 7.0
