### PR TITLE
Type defaulting warning

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1223,7 +1223,7 @@ getSocketOption (MkSocket s _ _ _ _) so = do
 getPeerCred :: Socket -> IO (CUInt, CUInt, CUInt)
 getPeerCred sock = do
   let fd = fdSocket sock
-  let sz = (fromIntegral (#const sizeof(struct ucred)))
+  let sz = #const sizeof(struct ucred)
   with sz $ \ ptr_cr ->
    alloca       $ \ ptr_sz -> do
      poke ptr_sz sz


### PR DESCRIPTION
When I compile network I get:

```
Network/Socket.hsc:1226:13:
    Warning: Defaulting the following constraint(s) to type `Integer'
               (Integral a0) arising from a use of `fromIntegral'
                             at Network/Socket.hsc:1226:13-24
               (Num a0) arising from the literal `12'
                        at Network/Socket.hsc:1226:27-28
    In the expression: (fromIntegral (12))
    In an equation for `sz': sz = (fromIntegral (12))
    In the expression:
      do { let fd = fdSocket sock;
           let sz = (fromIntegral (12));
             with sz $ \ ptr_cr -> alloca $ \ ptr_sz -> ... }
```

Evidently the fromIntegral is not necessary here; the fix is simple and (I hope) uncontroversial.
