### PR TITLE
User defined sockaddr

### DIFF
--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -239,6 +239,9 @@ data SockAddr       -- C Names
   | SockAddrUnix
         String          -- sun_path
 #endif
+  | SockAddrRaw
+        Family          -- socket family
+        [Word8]         -- raw bytes
   deriving (Eq)
 
 #if defined(WITH_WINSOCK) || defined(cygwin32_HOST_OS)
@@ -263,6 +266,7 @@ sizeOfSockAddr (SockAddrInet _ _) = #const sizeof(struct sockaddr_in)
 #if defined(IPV6_SOCKET_SUPPORT)
 sizeOfSockAddr (SockAddrInet6 _ _ _ _) = #const sizeof(struct sockaddr_in6)
 #endif
+sizeOfSockAddr (SockAddrRaw _ bytes) = (#const sizeof(sa_family_t)) + length bytes
 
 -- | Computes the storage requirements (in bytes) required for a
 -- 'SockAddr' with the given 'Family'.
@@ -335,6 +339,12 @@ pokeSockAddr p (SockAddrInet6 (PortNum port) flow addr scope) = do
     (#poke struct sockaddr_in6, sin6_addr) p addr
     (#poke struct sockaddr_in6, sin6_scope_id) p scope
 #endif
+pokeSockAddr p sa@(SockAddrRaw family bytes) = do
+#if defined(darwin_TARGET_OS)
+    zeroMemory p (sizeOfSockAddr sa)
+#endif
+    (#poke struct sockaddr, sa_family) p (fromIntegral (packFamily family) :: CSaFamily)
+    pokeArray ((#ptr struct sockaddr, sa_data) p) bytes
 
 -- | Read a 'SockAddr' from the given memory location.
 peekSockAddr :: Ptr SockAddr -> IO SockAddr


### PR DESCRIPTION
This pull request extends the sockaddr type with a SockAddrRaw with permits users to use other socket family without having to define all types of sockaddr (in my case netlink which is linux specific). It has some caveats, since the sockaddr doesn't have any length, there's no way to peek back the structure to the haskell type. It might be a bit too OS specific or type unsafe for the network packet, let me know if i can improve the situation somehow.

Hopefully it does improve the situation since there's lots of socket family defined, that doesn't have a way to be use since they are missing their equivalent sockaddr.

I've tested the patch with the following code to receive udev events on linux:

   main = do
        sock <- socket AF_ROUTE Raw 15
        let netlinksockaddr =
                [ 0, 0       -- nl_pad
                , 0, 0, 0, 0 -- nl_pid
                , 1, 0, 0, 0 -- nl_group
                ]
        bind sock (SockAddrRaw AF_ROUTE netlinksockaddr)
        (pid, _, _) <- getPeerCred sock
        forever $ do
                z <- recv sock 8192
                putStrLn $ show z
