### PR TITLE
IPv6Only

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -240,7 +240,9 @@ listen' serv = do
 	(sClose)
 	(\sock -> do
 	    setSocketOption sock ReuseAddr 1
+#ifdef HAVE_DECL_IPV6_V6ONLY
 	    setSocketOption sock IPv6Only 0
+#endif
 	    bindSocket sock (addrAddress addr)
 	    listen sock maxListenQueue
 	    return sock

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -919,7 +919,7 @@ data SocketOption
 #ifdef SO_USELOOPBACK
     | UseLoopBack   {- SO_USELOOPBACK -}
 #endif
-#ifdef IPV6_V6ONLY
+#ifdef HAVE_DECL_IPV6_V6ONLY
     | IPv6Only      {- IPV6_V6ONLY -}
 #endif
 
@@ -937,7 +937,7 @@ socketOptLevel so =
 #ifdef TCP_NODELAY
     NoDelay      -> #const IPPROTO_TCP
 #endif
-#ifdef IPV6_V6ONLY
+#ifdef HAVE_DECL_IPV6_V6ONLY
     IPv6Only     -> #const IPPROTO_IPV6
 #endif
     _            -> #const SOL_SOCKET
@@ -1005,7 +1005,7 @@ packSocketOption so =
 #ifdef SO_USELOOPBACK
     UseLoopBack   -> #const SO_USELOOPBACK
 #endif
-#ifdef IPV6_V6ONLY
+#ifdef HAVE_DECL_IPV6_V6ONLY
     IPv6Only      -> #const IPV6_V6ONLY
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,11 @@ dnl * test for AI_* flags that not all implementations have
 dnl -------------------------------------------------------
 AC_CHECK_DECLS([AI_ADDRCONFIG, AI_ALL, AI_NUMERICSERV, AI_V4MAPPED])
 
+dnl -------------------------------------------------------
+dnl * test for IPV6_V6ONLY flags that not all implementations have
+dnl -------------------------------------------------------
+AC_CHECK_DECLS([IPV6_V6ONLY])
+
 dnl --------------------------------------------------
 dnl * test for Linux sendfile(2)
 dnl --------------------------------------------------


### PR DESCRIPTION
Linux and BSD have a different default value for the IPV6_V6ONLY socket option. This patch sets it to false so that a listening socket can accept both IPv4 and IPv6 by default. Also, this patch discloses the IPV6_V6ONLY option to Haskell users so that they can change it.
