### PR TITLE
fixing a bug of setSocketOption

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1018,7 +1018,7 @@ setSocketOption (MkSocket s _ _ _ _) so v = do
    with (fromIntegral v) $ \ptr_v -> do
    throwErrnoIfMinus1_ "setSocketOption" $
        c_setsockopt s (socketOptLevel so) (packSocketOption so) ptr_v 
-          (fromIntegral (sizeOf v))
+          (fromIntegral (sizeOf (undefined :: CInt)))
    return ()
 
 


### PR DESCRIPTION
Since setSocketOption is using Int instead of CInt, it gets "invalid arguments" error. This error can be re-produced on Lion with the following code:

---

module Main where

import Network.Socket

main :: IO ()
main = do
    sock <- socket AF_INET6 Stream defaultProtocol
    setSocketOption sock IPv6Only 1
##     getSocketOption sock IPv6Only >>= print

Note: since IPv6Only is also buggy, the socket function never set IPv6Only to 0. Thus this code is suitable for testing of the bug of getSocketOption. I will send another pull requests for IPv6Only after this patch is merged.
