### PR TITLE
Add ghc-prof-options to network.buildinfo.in

### DIFF
--- a/network.buildinfo.in
+++ b/network.buildinfo.in
@@ -1,4 +1,5 @@
 ghc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
+ghc-prof-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
 cc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
 c-sources: @EXTRA_SRCS@
 extra-libraries: @EXTRA_LIBS@


### PR DESCRIPTION
This seems to be necessary on ghc-7.4.1 when library profiling is enabled.
