### PR TITLE
using accept4 on Linux.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,8 @@ AC_EGREP_HEADER(sendfile, sys/socket.h,
 
 AC_CHECK_FUNCS(gethostent)
 
+AC_CHECK_FUNCS(accept4)
+
 case "$host" in
 *-mingw32)
 	EXTRA_SRCS="cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c"


### PR DESCRIPTION
To avoid two fcntl, use accept4 with SOCK_NONBLOCK on Linux.
