### PR TITLE
Network.Socket.socketToHandle returns a buffered handle

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1813,6 +1813,7 @@ socketToHandle s@(MkSocket fd _ _ _ socketStatus) mode = do
 # elif defined(__HUGS__)
     h <- openFd (fromIntegral fd) True{-is a socket-} mode True{-bin-}
 # endif
+    hSetBuffering h NoBuffering
     return (ConvertedToHandle, h)
 #else
 socketToHandle (MkSocket s family stype protocol status) m =


### PR DESCRIPTION
With GHC 7.4.2, socketToHandle returns a buffered handle. This contradicts to the documentation.
