### PR TITLE
Fix documentation of listenOn

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -176,7 +176,7 @@ connect' host serv = do
 -- 'Network.Socket.listen' instead.
 
 listenOn :: PortID      -- ^ Port Identifier
-         -> IO Socket   -- ^ Connected Socket
+         -> IO Socket   -- ^ Listening Socket
 
 #if defined(IPV6_SOCKET_SUPPORT)
 -- IPv6 and IPv4.


### PR DESCRIPTION
It says that the socket returned is a connected one, but it is just a listening one.
accept is used to get a connected one from that.
