### PR TITLE
Request Winsock API version 2.2 instead of 1.1

### DIFF
--- a/cbits/initWinSock.c
+++ b/cbits/initWinSock.c
@@ -18,7 +18,7 @@ initWinSock ()
 #endif
 
   if (!winsock_inited) {
-    wVersionRequested = MAKEWORD( 1, 1 );
+    wVersionRequested = MAKEWORD( 2, 2 );
 
     err = WSAStartup ( wVersionRequested, &wsaData );
     
@@ -26,8 +26,8 @@ initWinSock ()
        return err;
     }
 
-    if ( LOBYTE( wsaData.wVersion ) != 1 ||
-       HIBYTE( wsaData.wVersion ) != 1 ) {
+    if ( LOBYTE( wsaData.wVersion ) != 2 ||
+       HIBYTE( wsaData.wVersion ) != 2 ) {
       WSACleanup();
       return (-1);
     }


### PR DESCRIPTION
Currently, `initWinSock.c` requests version 1.1 of the Winsock API, even though we are including `winsock2.h`.  I doubt this is intentional, given that `initWinSock.c` has barely been touched since 2003.  Winsock 1.1 is very very old (Windows 95 era).

I don't know what impact this change will have on applications.  I haven't been able to find a clear explanation of the differences between the Winsock API versions.
