### PR TITLE
Binding to user-defined socked addresses

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -315,6 +315,12 @@ instance Show SockAddr where
    . showString "]:"
    . shows port
 #endif
+  showsPrec _ (SockAddrRaw family raw_data)
+   = showString "{Raw("
+   . shows family
+   . showString ") "
+   . shows raw_data
+   . showString "}"
 
 -----------------------------------------------------------------------------
 -- Connection Functions

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -807,7 +807,8 @@ sizeOfSockAddr (SockAddrInet _ _) = #const sizeof(struct sockaddr_in)
 #if defined(IPV6_SOCKET_SUPPORT)
 sizeOfSockAddr (SockAddrInet6 _ _ _ _) = #const sizeof(struct sockaddr_in6)
 #endif
-sizeOfSockAddr (SockAddrRaw _ bytes) = (#const sizeof(sa_family_t)) + length bytes
+sizeOfSockAddr (SockAddrRaw _ bytes) =
+    max (#const sizeof(struct sockaddr)) $ (#const sizeof(sa_family_t)) + length bytes
 
 -- | Computes the storage requirements (in bytes) required for a
 -- 'SockAddr' with the given 'Family'.


### PR DESCRIPTION
As requested in #11, I've reapplied 414edbb4 to current master.

I haven't throughly tested this patch, but `cabal test` passes fine (so no existing functionality seems to be broken) and example from #11 OP works fine, showing udev events as expected.
