### PR TITLE
MsgHdr.hsc: fix field 'struct msghdr::msg_namelen' size

### DIFF
--- a/Network/Socket/ByteString/MsgHdr.hsc
+++ b/Network/Socket/ByteString/MsgHdr.hsc
@@ -8,6 +8,7 @@ module Network.Socket.ByteString.MsgHdr
 #include <sys/types.h>
 #include <sys/socket.h>
 
+import Data.Word -- for used '#type's
 import Foreign.C.Types (CInt, CSize)
 import Foreign.Ptr (Ptr)
 import Foreign.Storable (Storable(..))
@@ -20,7 +21,7 @@ import Network.Socket.ByteString.IOVec (IOVec)
 -- don't exist on OpenSolaris.
 data MsgHdr = MsgHdr
     { msgName    :: Ptr SockAddr
-    , msgNameLen :: CSize
+    , msgNameLen :: (#type socklen_t) {- 32 bits even on amd64 and ppc64 -}
     , msgIov     :: Ptr IOVec
     , msgIovLen  :: CSize
     }


### PR DESCRIPTION
msg_namelen has a 'socklen_t' type on linux (always 32 bits).
Using CSize there breaks 64-bit BE platforms.

  testSendManyTo: [Failed]
       ERROR: sendmsg: invalid argument (Destination address required)

Caught by testSendManyTo test on ppc64:

Gentoo-bug: http://bugs.gentoo.org/436640
Reported-by: Anthony Basile blueness@gentoo.org
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
