### PR TITLE
defining __USE_XOPEN for MAX_IOV.

### DIFF
--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -58,6 +58,10 @@ extern int   acceptDoProc(void* param);
 
 #else
 
+/*
+ To use IOV_MAX, "limits.h" is included. On old Linux,
+ __USE_XOPEN is necessary to use IOV_MAX in "limits.h".
+*/
 #ifndef __USE_XOPEN
 # define __USE_XOPEN
 #endif


### PR DESCRIPTION
On old Linux, network 2.4.1.0 cannot be compiled:

```
Preprocessing library network-2.4.1.0...
ByteString.hsc: In function ‘main’:
ByteString.hsc:204: error: ‘IOV_MAX’ undeclared (first use in this function)
ByteString.hsc:204: error: (Each undeclared identifier is reported only once
ByteString.hsc:204: error: for each function it appears in.)
compiling dist/build/Network/Socket/ByteString_hsc_make.c failed (exit code 1)
command was: /home/kazu/bin/gcc -c dist/build/Network/Socket/ByteString_hsc_make.c -o dist/build/Network/Socket/ByteString_hsc_make.o -fno-stack-protector -fno-stack-protector -D__GLASGOW_HASKELL__=700 -Dlinux_BUILD_OS -Dlinux_HOST_OS -Di386_BUILD_ARCH -Di386_HOST_ARCH -Iinclude -DCALLCONV=ccall -I/ghc7.0.4/lib/ghc-7.0.4/unix-2.4.2.0/include -I/ghc7.0.4/lib/ghc-7.0.4/bytestring-0.9.1.10/include -I/ghc7.0.4/lib/ghc-7.0.4/base-4.3.1.0/include -I/ghc7.0.4/lib/ghc-7.0.4/include -I/ghc7.0.4/lib/ghc-7.0.4/include -I/ghc7.0.4/lib/ghc-7.0.4/include/
```

This patch fixes this problem.
