### PR TITLE
changed getPeerCred and add getPeerEid to support FreeBSD

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -82,9 +82,12 @@ module Network.Socket
     , getPeerName
     , getSocketName
 
-#ifdef HAVE_STRUCT_UCRED
+#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
     -- get the credentials of our domain socket peer.
     , getPeerCred
+#if defined(HAVE_GETPEEREID) 
+    , getPeerEid
+#endif
 #endif
 
     , socketPort
@@ -983,12 +986,15 @@ getSocketOption (MkSocket s _ _ _ _) so = do
        fromIntegral `liftM` peek ptr_v
 
 
-#ifdef HAVE_STRUCT_UCRED
+#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
 -- | Returns the processID, userID and groupID of the socket's peer.
 --
--- Only available on platforms that support SO_PEERCRED on domain sockets.
+-- Only available on platforms that support SO_PEERCRED or GETPEEREID(3)
+-- on domain sockets.
+-- GETPEEREID(3) returns userID and groupID. processID is always 0.
 getPeerCred :: Socket -> IO (CUInt, CUInt, CUInt)
 getPeerCred sock = do
+#ifdef HAVE_STRUCT_UCRED
   let fd = fdSocket sock
   let sz = (fromIntegral (#const sizeof(struct ucred)))
   with sz $ \ ptr_cr ->
@@ -1000,6 +1006,25 @@ getPeerCred sock = do
      uid <- (#peek struct ucred, uid) ptr_cr
      gid <- (#peek struct ucred, gid) ptr_cr
      return (pid, uid, gid)
+#else
+  (uid,gid) <- getPeerEid sock
+  return (0,uid,gid)
+#endif
+
+#ifdef HAVE_GETPEEREID
+-- | The getpeereid() function returns the effective user and group IDs of the
+-- peer connected to a UNIX-domain socket
+getPeerEid :: Socket -> IO (CUInt, CUInt)
+getPeerEid sock = do 
+  let fd = fdSocket sock
+  alloca $ \ ptr_uid ->
+    alloca $ \ ptr_gid -> do
+      throwSocketErrorIfMinus1Retry "getPeerEid" $
+        c_getpeereid fd ptr_uid ptr_gid
+      uid <- peek ptr_uid
+      gid <- peek ptr_gid
+      return (uid, gid)
+#endif
 #endif
 
 ##if !(MIN_VERSION_base(4,3,1))
@@ -1634,6 +1659,10 @@ foreign import CALLCONV unsafe "getsockopt"
 foreign import CALLCONV unsafe "setsockopt"
   c_setsockopt :: CInt -> CInt -> CInt -> Ptr CInt -> CInt -> IO CInt
 
+#if defined(HAVE_GETPEEREID)
+foreign import CALLCONV unsafe "getpeereid"
+  c_getpeereid :: CInt -> Ptr CUInt -> Ptr CUInt -> IO CInt
+#endif
 -- ---------------------------------------------------------------------------
 -- * Deprecated aliases
 

--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,12 @@ else
 fi
 
 dnl --------------------------------------------------
+dnl * test for GETPEEREID(3) 
+dnl --------------------------------------------------
+AC_MSG_CHECKING(for getpeereid in unistd.h)
+AC_CHECK_FUNC( getpeereid, AC_DEFINE([HAVE_GETPEEREID], [1], [Define to 1 if you have getpeereid.] ))
+
+dnl --------------------------------------------------
 dnl * check for Windows networking libraries
 dnl --------------------------------------------------
 AC_CHECK_LIB(ws2_32, _head_libws2_32_a)

--- a/tests/Simple.hs
+++ b/tests/Simple.hs
@@ -112,6 +112,67 @@ testOverFlowRecvFrom = tcpTest client server
 
     client sock = send sock testMsg
 
+{-
+testGetPeerCred:: Assertion
+testGetPeerCred =
+    test clientSetup clientAct serverSetup server
+  where
+    clientSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        connect sock $ SockAddrUnix addr 
+        return sock
+
+    serverSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        bindSocket sock $ SockAddrUnix addr 
+        listen sock 1
+        return sock
+
+    server sock = do
+        (clientSock, _) <- accept sock
+        serverAct clientSock
+        sClose clientSock
+
+    addr = "/tmp/testAddr1"
+    clientAct sock = withSocketsDo $ do  
+                     sendAll sock testMsg
+                     (pid,uid,gid) <- getPeerCred sock
+                     putStrLn $ unwords ["pid=",show pid,"uid=",show uid, "gid=", show gid]
+    serverAct sock = withSocketsDo $ do
+                     msg <- recv sock 1024
+                     putStrLn $ C.unpack msg
+
+
+testGetPeerEid :: Assertion
+testGetPeerEid =  
+    test clientSetup clientAct serverSetup server
+  where
+    clientSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        connect sock $ SockAddrUnix addr 
+        return sock
+
+    serverSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        bindSocket sock $ SockAddrUnix addr 
+        listen sock 1
+        return sock
+
+    server sock = do
+        (clientSock, _) <- accept sock
+        serverAct clientSock
+        sClose clientSock
+
+    addr = "/tmp/testAddr2"
+    clientAct sock = withSocketsDo $ do  
+                     sendAll sock testMsg
+                     (uid,gid) <- getPeerEid sock
+                     putStrLn $ unwords ["uid=",show uid, "gid=", show gid]
+    serverAct sock = withSocketsDo $ do
+                     msg <- recv sock 1024
+                     putStrLn $ C.unpack msg
+-}
+
 ------------------------------------------------------------------------
 -- Other
 
@@ -132,6 +193,8 @@ basicTests = testGroup "Basic socket operations"
     , testCase "testOverFlowRecv" testOverFlowRecv
     , testCase "testRecvFrom" testRecvFrom
     , testCase "testOverFlowRecvFrom" testOverFlowRecvFrom
+--    , testCase "testGetPeerCred" testGetPeerCred
+--    , testCase "testGetPeerEid" testGetPeerEid
     ]
 
 tests :: [Test]


### PR DESCRIPTION
Hello.

getPeerCred was changed so that it might operate by FreeBSD. 
It desires to add getPeerEid so that GETPEEREID (3) can be used. 

http://www.freebsd.org/cgi/man.cgi?query=getpeereid

---

I am poor at English. 
Please allow, if a message has impoliteness. 
