### PR TITLE
fixing regression of accept4.

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -510,19 +510,16 @@ accept sock@(MkSocket s family stype protocol status) = do
                 return new_sock
 #else
      with (fromIntegral sz) $ \ ptr_len -> do
-     new_sock <-
 # ifdef HAVE_ACCEPT4
-                 throwSocketErrorIfMinus1RetryMayBlock "accept"
+     new_sock <- throwSocketErrorIfMinus1RetryMayBlock "accept"
                         (threadWaitRead (fromIntegral s))
                         (c_accept4 s sockaddr ptr_len (#const SOCK_NONBLOCK))
 # else
-                 throwSocketErrorWaitRead sock "accept"
+     new_sock <- throwSocketErrorWaitRead sock "accept"
                         (c_accept s sockaddr ptr_len)
+     setNonBlockIfNeeded new_sock
 # endif /* HAVE_ACCEPT4 */
 #endif
-#ifndef HAVE_ACCEPT4
-     setNonBlockIfNeeded new_sock
-#endif /* HAVE_ACCEPT4 */
      addr <- peekSockAddr sockaddr
      new_status <- newMVar Connected
      return ((MkSocket new_sock family stype protocol new_status), addr)


### PR DESCRIPTION
accept4 sets a socket non-blocking. So, we don't need to set it again.

I think that ec2cdfe13c267c3aa8752af31f70ba474f8d46c8 causes this regression.
