### PR TITLE
configure script should accept --with-gcc flag instead of --with-cc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_CONFIG_HEADERS([include/HsNetworkConfig.h])
 
 AC_CANONICAL_HOST
 
-AC_ARG_WITH([cc],
+AC_ARG_WITH([gcc],
             [C compiler],
             [CC=$withval])
 AC_PROG_CC()


### PR DESCRIPTION
This should prevent problems like #103
The "with-gcc" is hardcoded into Cabal, so it's probably easier to change our configure script than to change Cabal.
