### PR TITLE
Move HSNet import to top of file (fixes compilation error)

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -1,6 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
+
+#include "HsNet.h"
+
 module Network.Socket.Types
     (
     -- * Socket
@@ -49,8 +52,6 @@ module Network.Socket.Types
     -- * Low-level helpers
     , zeroMemory
     ) where
-
-#include "HsNet.h"
 
 import Control.Concurrent.MVar
 import Control.Monad


### PR DESCRIPTION
It was below '#if defined(IPV6_SOCKET_SUPPORT)', which requires it.
