### PR TITLE
Fix documentation for Network.sClose, which is incorrectly labeled as deprecated

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -4,7 +4,7 @@
 -- Module      :  Network
 -- Copyright   :  (c) The University of Glasgow 2001
 -- License     :  BSD-style (see the file libraries/network/LICENSE)
--- 
+--
 -- Maintainer  :  libraries@haskell.org
 -- Stability   :  provisional
 -- Portability :  portable
@@ -32,7 +32,7 @@ module Network
 
     -- * Initialisation
     , withSocketsDo
-    
+
     -- * Server-side connections
     , listenOn
     , accept
@@ -78,7 +78,7 @@ import qualified Control.Exception as Exception
 -- raised. Alternatively an empty string may be given to @connectTo@
 -- signalling that the current hostname applies.
 
-data PortID = 
+data PortID =
           Service String                -- Service Name eg "ftp"
         | PortNumber PortNumber         -- User defined Port Number
 #if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
@@ -89,7 +89,7 @@ data PortID =
 -- | Calling 'connectTo' creates a client side socket which is
 -- connected to the given host and port.  The Protocol and socket type is
 -- derived from the given port identifier.  If a port number is given
--- then the result is always an internet family 'Stream' socket. 
+-- then the result is always an internet family 'Stream' socket.
 
 connectTo :: HostName           -- Hostname
           -> PortID             -- Port Identifier
@@ -268,14 +268,14 @@ listen' serv = do
 accept :: Socket                -- ^ Listening Socket
        -> IO (Handle,
               HostName,
-              PortNumber)       -- ^ Triple of: read\/write 'Handle' for 
+              PortNumber)       -- ^ Triple of: read\/write 'Handle' for
                                 -- communicating with the client,
                                 -- the 'HostName' of the peer socket, and
                                 -- the 'PortNumber' of the remote connection.
 accept sock@(MkSocket _ AF_INET _ _ _) = do
  ~(sock', (SockAddrInet port haddr)) <- Socket.accept sock
  peer <- catchIO
-          (do   
+          (do
              (HostEntry peer _ _ _) <- getHostByAddr AF_INET haddr
              return peer
           )
@@ -369,7 +369,7 @@ recvFrom host port = do
  ip  <- getHostByName host
  let ipHs = hostAddresses ip
  s   <- listenOn port
- let 
+ let
   waiting = do
      ~(s', SockAddrInet _ haddr)  <-  Socket.accept s
      he <- getHostByAddr AF_INET haddr
@@ -408,7 +408,7 @@ socketPort s = do
 -- ---------------------------------------------------------------------------
 -- Utils
 
--- Like bracket, but only performs the final action if there was an 
+-- Like bracket, but only performs the final action if there was an
 -- exception raised by the middle bit.
 bracketOnError
         :: IO a         -- ^ computation to run first (\"acquire resource\")

--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -4,7 +4,7 @@
 -- Module      :  Network.BSD
 -- Copyright   :  (c) The University of Glasgow 2001
 -- License     :  BSD-style (see the file libraries/network/LICENSE)
--- 
+--
 -- Maintainer  :  libraries@haskell.org
 -- Stability   :  experimental
 -- Portability :  non-portable
@@ -141,7 +141,7 @@ type ProtocolName = String
 -- close the database a call to endServiceEntry is required.  This
 -- database file is usually stored in the file /etc/services.
 
-data ServiceEntry  = 
+data ServiceEntry  =
   ServiceEntry  {
      serviceName     :: ServiceName,    -- Official Name
      serviceAliases  :: [ServiceName],  -- aliases
@@ -187,7 +187,7 @@ getServiceByName name proto = withLock $ do
    $ (trySysCall (c_getservbyname cstr_name cstr_proto))
  >>= peek
 
-foreign import CALLCONV unsafe "getservbyname" 
+foreign import CALLCONV unsafe "getservbyname"
   c_getservbyname :: CString -> CString -> IO (Ptr ServiceEntry)
 
 -- | Get the service given a 'PortNumber' and 'ProtocolName'.
@@ -198,7 +198,7 @@ getServiceByPort (PortNum port) proto = withLock $ do
    $ (trySysCall (c_getservbyport (fromIntegral port) cstr_proto))
  >>= peek
 
-foreign import CALLCONV unsafe "getservbyport" 
+foreign import CALLCONV unsafe "getservbyport"
   c_getservbyport :: CInt -> CString -> IO (Ptr ServiceEntry)
 
 -- | Get the 'PortNumber' corresponding to the 'ServiceName'.
@@ -242,9 +242,9 @@ getServiceEntries stayOpen = do
 -- As for setServiceEntry above, calling setProtocolEntry.
 -- determines whether or not the protocol database file, usually
 -- @/etc/protocols@, is to be kept open between calls of
--- getProtocolEntry. Similarly, 
+-- getProtocolEntry. Similarly,
 
-data ProtocolEntry = 
+data ProtocolEntry =
   ProtocolEntry  {
      protoName    :: ProtocolName,      -- Official Name
      protoAliases :: [ProtocolName],    -- aliases
@@ -264,12 +264,12 @@ instance Storable ProtocolEntry where
          -- With WinSock, the protocol number is only a short;
          -- hoist it in as such, but represent it on the Haskell side
          -- as a CInt.
-        p_proto_short  <- (#peek struct protoent, p_proto) p 
+        p_proto_short  <- (#peek struct protoent, p_proto) p
         let p_proto = fromIntegral (p_proto_short :: CShort)
 #else
-        p_proto        <- (#peek struct protoent, p_proto) p 
+        p_proto        <- (#peek struct protoent, p_proto) p
 #endif
-        return (ProtocolEntry { 
+        return (ProtocolEntry {
                         protoName    = p_name,
                         protoAliases = p_aliases,
                         protoNumber  = p_proto
@@ -284,7 +284,7 @@ getProtocolByName name = withLock $ do
    $ (trySysCall.c_getprotobyname) name_cstr
  >>= peek
 
-foreign import  CALLCONV unsafe  "getprotobyname" 
+foreign import  CALLCONV unsafe  "getprotobyname"
    c_getprotobyname :: CString -> IO (Ptr ProtocolEntry)
 
 
@@ -331,7 +331,7 @@ getProtocolEntries stayOpen = withLock $ do
 -- ---------------------------------------------------------------------------
 -- Host lookups
 
-data HostEntry = 
+data HostEntry =
   HostEntry  {
      hostName      :: HostName,         -- Official Name
      hostAliases   :: [HostName],       -- aliases
@@ -385,7 +385,7 @@ getHostByName name = withLock $ do
                 $ trySysCall $ c_gethostbyname name_cstr
    peek ent
 
-foreign import CALLCONV safe "gethostbyname" 
+foreign import CALLCONV safe "gethostbyname"
    c_gethostbyname :: CString -> IO (Ptr HostEntry)
 
 
@@ -460,7 +460,7 @@ instance Storable NetworkEntry where
         return (NetworkEntry {
                         networkName      = n_name,
                         networkAliases   = n_aliases,
-                        networkFamily    = unpackFamily (fromIntegral 
+                        networkFamily    = unpackFamily (fromIntegral
                                                         (n_addrtype :: CInt)),
                         networkAddress   = n_net
                 })
@@ -476,7 +476,7 @@ getNetworkByName name = withLock $ do
     $ trySysCall $ c_getnetbyname name_cstr
   >>= peek
 
-foreign import ccall unsafe "getnetbyname" 
+foreign import ccall unsafe "getnetbyname"
    c_getnetbyname  :: CString -> IO (Ptr NetworkEntry)
 
 getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
@@ -485,7 +485,7 @@ getNetworkByAddr addr family = withLock $ do
    $ trySysCall $ c_getnetbyaddr addr (packFamily family)
  >>= peek
 
-foreign import ccall unsafe "getnetbyaddr" 
+foreign import ccall unsafe "getnetbyaddr"
    c_getnetbyaddr  :: NetworkAddr -> CInt -> IO (Ptr NetworkEntry)
 
 getNetworkEntry :: IO NetworkEntry
@@ -539,7 +539,7 @@ getHostName = do
     throwSocketErrorIfMinus1_ "getHostName" $ c_gethostname cstr (fromIntegral size)
     peekCString cstr
 
-foreign import CALLCONV unsafe "gethostname" 
+foreign import CALLCONV unsafe "gethostname"
    c_gethostname :: CString -> CSize -> IO CInt
 
 -- Helper function used by the exported functions that provides a

--- a/Network/Socket/ByteString.hsc
+++ b/Network/Socket/ByteString.hsc
@@ -23,7 +23,7 @@
 -- > import Network.Socket.ByteString
 --
 module Network.Socket.ByteString
-    ( 
+    (
     -- * Send data to a socket
       send
     , sendAll

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -64,13 +64,13 @@ module Network.URI
       URI(..)
     , URIAuth(..)
     , nullURI
-      
+
     -- * Parsing
     , parseURI
     , parseURIReference
     , parseRelativeReference
     , parseAbsoluteURI
-      
+
     -- * Test for strings containing various kinds of URI
     , isURI
     , isURIReference
@@ -78,16 +78,16 @@ module Network.URI
     , isAbsoluteURI
     , isIPv6address
     , isIPv4address
-      
+
     -- * Predicates
     , uriIsAbsolute
     , uriIsRelative
-      
+
     -- * Relative URIs
     , relativeTo
     , nonStrictRelativeTo
     , relativeFrom
-      
+
     -- * Operations on URI strings
     -- | Support for putting strings into URI-friendly
     --   escaped format and getting them back again.
@@ -103,12 +103,12 @@ module Network.URI
     , escapeURIChar
     , escapeURIString
     , unEscapeString
-      
+
     -- * URI Normalization functions
     , normalizeCase
     , normalizeEscape
     , normalizePathSegments
-      
+
     -- * Deprecated functions
     , parseabsoluteURI
     , escapeString


### PR DESCRIPTION
`Network.sClose` is a re-export of the deprecated function `Network.Socket.sClose`, and is therefore marked as deprecated in the docs (just as a remark, not in the pragma sense). This patch fixes the issue by explicitly redefining `sClose` in terms of `Network.Socket.close` with the docs copied over from there.

I also removed trailing whitespace from the Haskell in a separate commit while I was at it.
