### PR TITLE
add ld options

### DIFF
--- a/network.buildinfo.in
+++ b/network.buildinfo.in
@@ -1,5 +1,6 @@
 ghc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
 ghc-prof-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
+ld-options: @LDFLAGS@
 cc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
 c-sources: @EXTRA_SRCS@
 extra-libraries: @EXTRA_LIBS@


### PR DESCRIPTION
Ability to set LDFLAGS for homebrew issue on Mac OS X because by default I got this error:

```
$ autoreconf
$ LDFLAGS=-L/usr/local/lib cabal install
Resolving dependencies...
In order, the following will be installed:
network-2.4.1.1 (latest: 2.4.1.2) (reinstall)
Warning: Note that reinstalls are always dangerous. Continuing anyway...
Configuring network-2.4.1.1...
configure: WARNING: unrecognized options: --with-compiler
checking build system type... i386-apple-darwin13.0.0
checking host system type... i386-apple-darwin13.0.0
checking for gcc... /usr/bin/gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether /usr/bin/gcc accepts -g... yes
checking for /usr/bin/gcc option to accept ISO C89... none needed
checking for an ANSI C-conforming const... yes
checking how to run the C preprocessor... /usr/bin/gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking limits.h usability... yes
checking limits.h presence... yes
checking for limits.h... yes
checking for stdlib.h... (cached) yes
checking for sys/types.h... (cached) yes
checking for unistd.h... (cached) yes
checking winsock2.h usability... no
checking winsock2.h presence... no
checking for winsock2.h... no
checking ws2tcpip.h usability... no
checking ws2tcpip.h presence... no
checking for ws2tcpip.h... no
checking wspiapi.h usability... no
checking wspiapi.h presence... no
checking for wspiapi.h... no
checking arpa/inet.h usability... yes
checking arpa/inet.h presence... yes
checking for arpa/inet.h... yes
checking netdb.h usability... yes
checking netdb.h presence... yes
checking for netdb.h... yes
checking netinet/in.h usability... yes
checking netinet/in.h presence... yes
checking for netinet/in.h... yes
checking netinet/tcp.h usability... yes
checking netinet/tcp.h presence... yes
checking for netinet/tcp.h... yes
checking sys/socket.h usability... yes
checking sys/socket.h presence... yes
checking for sys/socket.h... yes
checking sys/uio.h usability... yes
checking sys/uio.h presence... yes
checking for sys/uio.h... yes
checking sys/un.h usability... yes
checking sys/un.h presence... yes
checking for sys/un.h... yes
checking for readlink... yes
checking for symlink... yes
checking for struct msghdr.msg_control... yes
checking for struct msghdr.msg_accrights... no
checking for struct sockaddr.sa_len... yes
checking for in_addr_t in netinet/in.h... yes
checking for SO_PEERCRED and struct ucred in sys/socket.h... no
checking for _head_libws2_32_a in -lws2_32... no
checking for getaddrinfo... yes
checking for gai_strerror... yes
checking whether AI_ADDRCONFIG is declared... yes
checking whether AI_ALL is declared... yes
checking whether AI_NUMERICSERV is declared... yes
checking whether AI_V4MAPPED is declared... yes
checking whether IPV6_V6ONLY is declared... yes
checking for sendfile in sys/sendfile.h... no
checking for sendfile in sys/socket.h... yes
checking for gethostent... yes
checking for accept4... no
configure: creating ./config.status
config.status: creating network.buildinfo
config.status: creating include/HsNetworkConfig.h
configure: WARNING: unrecognized options: --with-compiler
Building network-2.4.1.1...
Preprocessing library network-2.4.1.1...
ld: library not found for -lgmp
clang: error: linker command failed with exit code 1 (use -v to see invocation)
linking dist/build/Network/BSD_hsc_make.o failed (exit code 1)
command was: /usr/bin/gcc dist/build/Network/BSD_hsc_make.o dist/build/Network/BSD_hsc_utils.o -o dist/build/Network/BSD_hsc_make -m64 -m64 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/unix-2.6.0.1 -ldl -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/time-1.4.0.1 -L/Users/timothyklim/.cabal/lib/x86_64-osx-ghc-7.6.3/parsec-3.1.3 -L/Users/timothyklim/.cabal/lib/x86_64-osx-ghc-7.6.3/text-0.11.3.1 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/old-locale-1.0.0.5 -L/Users/timothyklim/.cabal/lib/x86_64-osx-ghc-7.6.3/mtl-2.1.2 -L/Users/timothyklim/.cabal/lib/x86_64-osx-ghc-7.6.3/transformers-0.3.0.0 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/bytestring-0.10.0.2 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/deepseq-1.3.0.1 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/array-0.4.0.1 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/base-4.6.0.1 -liconv -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/integer-gmp-0.5.0.0 -lgmp -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3/ghc-prim-0.3.0.0 -L/usr/local/Cellar/ghc/7.6.3/lib/ghc-7.6.3 -lm -ldl
Failed to install network-2.4.1.1
cabal: Error: some packages failed to install:
network-2.4.1.1 failed during the building phase. The exception was:
ExitFailure 1
```

and network.buildinfo contents:

```
ghc-options: -DCALLCONV=ccall
ghc-prof-options: -DCALLCONV=ccall
cc-options: -DCALLCONV=ccall
c-sources: cbits/ancilData.c
extra-libraries:
```

with this patch I can compile network package with LDFLAGS.
