### PR TITLE
Remove the last traces of Typeable.h

### DIFF
--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -16,9 +16,6 @@
 
 #include "HsNet.h"
 
--- NOTE: ##, we want this interpreted when compiling the .hs, not by hsc2hs.
-##include "Typeable.h"
-
 module Network.BSD
     (
     -- * Host names

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -22,9 +22,6 @@
 
 #include "HsNet.h"
 
--- NOTE: ##, we want this interpreted when compiling the .hs, not by hsc2hs.
-##include "Typeable.h"
-
 -- In order to process this file, you need to have CALLCONV defined.
 
 module Network.Socket

--- a/include/Makefile
+++ b/include/Makefile
@@ -7,12 +7,7 @@ include $(TOP)/mk/boilerplate.mk
 H_FILES = $(wildcard *.h)
 
 includedir = $(libdir)/include
-
-# Typeable.h doesn't need to be installed, and in fact it'll clobber the
-# Typeable.h from package base (which arguably doesn't need to be installed
-# either, but apparently some people use it...).  See bug #1106.  The Cabal
-# description for network already does the right thing here.
-INSTALL_INCLUDES = $(filter-out Typeable.h,$(H_FILES))
+INSTALL_INCLUDES = $(H_FILES)
 
 DIST_CLEAN_FILES += HsNetworkConfig.h
 


### PR DESCRIPTION
Reverts 7774c9300, as we no longer include a Typeable.h, and removes
some leftover references to base's Typeable.h (which we no longer use,
and will disappear in GHC 7.10).
