### PR TITLE
Replace __GNUC__ with __GNUC__GNU_INLINE__ in HsNet to fix linking error...

### DIFF
--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -23,7 +23,7 @@
 #ifndef INLINE
 # if defined(_MSC_VER)
 #  define INLINE extern __inline
-# elif defined(__GNUC__)
+# elif defined(__GNUC_GNU_INLINE__)
 #  define INLINE extern inline
 # else
 #  define INLINE inline


### PR DESCRIPTION
on OS X, as discussed in #100. Fixes #100
