### PR TITLE
Treat SockAddrUnix "" specially in sizeOfSockAddr

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -801,6 +801,7 @@ sizeOfSockAddr :: SockAddr -> Int
 sizeOfSockAddr (SockAddrUnix path) =
     case path of
         '\0':_ -> (#const sizeof(sa_family_t)) + length path
+        ""     -> #const sizeof(sa_family_t)
         _      -> #const sizeof(struct sockaddr_un)
 #endif
 sizeOfSockAddr (SockAddrInet _ _) = #const sizeof(struct sockaddr_in)


### PR DESCRIPTION
As can be seen in unix(7), section "Autobind feature", the Linux kernel
treats sockaddr_un's with a length of sizeof(sa_family_t) (which are
therefore completely missing the sun_path part) specially by
automatically assigning an abstract address on a bind() call using such
a sockaddr_un.

This can only be used from Haskell if sizeOfSockAddr returns
sizeof(sa_family_t) for such a SockAddr, and not sizeof(struct
sockaddr_un) as it's currently the case.

This shouldn't hurt portability to other UNIX systems, however I'm not
sure about the implications for the rest of the code, especially for
pokeSockAddr. It seemed to work fine when I tested it, but please check
if it causes any buffer overflows or similar problems.

With this patch applied, the autobind feature could be used by
'bind sock $ SockAddrUnix ""'.
