### PR TITLE
Recommend against Network's use in haddock summary

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -9,9 +9,11 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- The "Network" interface is a \"higher-level\" interface to
--- networking facilities, and it is recommended unless you need the
--- lower-level interface in "Network.Socket".
+-- This module is kept for backwards-compatibility. New users are
+-- encouraged to use "Network.Socket" instead.
+--
+-- "Network" was intended as a \"higher-level\" interface to networking
+-- facilities, and only supports TCP.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Per Tibbe's comment in Github issue #124:

```
Aside: the whole Network module is unfortunately a bit ill-conceived
(e.g. it assumes TCP only). We will keep it for backwards compatibility
but new users should really use Network.Socket.

(from https://github.com/haskell/network/issues/124#issuecomment-36513742)
```

I came here to suggest that Network.PortID's constructors not be exported, but it sounds like this might be a more general solution. 
