### PR TITLE
Provide a way of building the package on Windows sytem without MSYS installed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist/*
 include/HsNetworkConfig.h
 include/HsNetworkConfig.h.in
 network.buildinfo
+.cabal-sandbox/
+cabal.sandbox.config

--- a/Network.hs
+++ b/Network.hs
@@ -17,7 +17,11 @@
 --
 -----------------------------------------------------------------------------
 
+#ifndef BUILDING_ON_WINDOWS
 #include "HsNetworkConfig.h"
+#else
+#include "HsNetworkConfigWin.h"
+#endif
 
 #ifdef HAVE_GETADDRINFO
 -- Use IPv6-capable function definitions if the OS supports it.

--- a/Setup.hs
+++ b/Setup.hs
@@ -7,7 +7,6 @@ import System.Environment
 main :: IO ()
 main = do
   msys <- lookupEnv "MSYSTEM"
-  writeFile "log.txt" (show $ ("MSYSTEM",msys))
   case (msys,buildOS) of
     (Nothing, Windows) -> defaultMain -- on Windows without MSYS use preconfigured headers and params
     _ -> defaultMainWithHooks autoconfUserHooks

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
 import Distribution.Simple
-import Distribution.System
-import System.Environment
+import Distribution.System (buildOS)
+import System.Environment (getEnvironment)
 
 main :: IO ()
 main = do

--- a/Setup.hs
+++ b/Setup.hs
@@ -6,7 +6,7 @@ import System.Environment
 
 main :: IO ()
 main = do
-  msys <- lookupEnv "MSYSTEM"
-  case (msys,buildOS) of
-    (Nothing, Windows) -> defaultMain -- on Windows without MSYS use preconfigured headers and params
+  msys'present <- (elem "MSYSTEM" . map fst) `fmap` getEnvironment
+  case (msys'present,buildOS) of
+    (False, Windows) -> defaultMain -- on Windows without MSYS use preconfigured headers and params
     _ -> defaultMainWithHooks autoconfUserHooks

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,13 @@
 module Main (main) where
 
 import Distribution.Simple
+import Distribution.System
+import System.Environment
 
 main :: IO ()
-main = defaultMainWithHooks autoconfUserHooks
+main = do
+  msys <- lookupEnv "MSYSTEM"
+  writeFile "log.txt" (show $ ("MSYSTEM",msys))
+  case (msys,buildOS) of
+    (Nothing, Windows) -> defaultMain -- on Windows without MSYS use preconfigured headers and params
+    _ -> defaultMainWithHooks autoconfUserHooks

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Distribution.Simple
-import Distribution.System (buildOS)
+import Distribution.System (buildOS,OS(..))
 import System.Environment (getEnvironment)
 
 main :: IO ()

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -7,7 +7,11 @@
 #ifndef HSNET_H
 #define HSNET_H
 
+#ifndef _WIN
 #include "HsNetworkConfig.h"
+#else
+#include "HsNetworkConfigWin.h"
+#endif
 
 #ifdef NEED_WINVER
 # define WINVER 0x0501

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -7,7 +7,7 @@
 #ifndef HSNET_H
 #define HSNET_H
 
-#ifndef _WIN
+#ifndef BUILDING_ON_WINDOWS
 #include "HsNetworkConfig.h"
 #else
 #include "HsNetworkConfigWin.h"

--- a/include/HsNetworkConfigWin.h
+++ b/include/HsNetworkConfigWin.h
@@ -1,0 +1,166 @@
+/* include/HsNetworkConfig.h.  Generated from HsNetworkConfig.h.in by configure.  */
+/* include/HsNetworkConfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the `accept4' function. */
+/* #undef HAVE_ACCEPT4 */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+/* #undef HAVE_ARPA_INET_H */
+
+/* Define to 1 if you have a BSDish sendfile(2) implementation. */
+/* #undef HAVE_BSD_SENDFILE */
+
+/* Define to 1 if you have the declaration of `AI_ADDRCONFIG', and to 0 if you
+   don't. */
+#define HAVE_DECL_AI_ADDRCONFIG 0
+
+/* Define to 1 if you have the declaration of `AI_ALL', and to 0 if you don't.
+   */
+#define HAVE_DECL_AI_ALL 0
+
+/* Define to 1 if you have the declaration of `AI_NUMERICSERV', and to 0 if
+   you don't. */
+#define HAVE_DECL_AI_NUMERICSERV 0
+
+/* Define to 1 if you have the declaration of `AI_V4MAPPED', and to 0 if you
+   don't. */
+#define HAVE_DECL_AI_V4MAPPED 0
+
+/* Define to 1 if you have the declaration of `IPPROTO_IP', and to 0 if you
+   don't. */
+#define HAVE_DECL_IPPROTO_IP 1
+
+/* Define to 1 if you have the declaration of `IPPROTO_IPV6', and to 0 if you
+   don't. */
+#define HAVE_DECL_IPPROTO_IPV6 1
+
+/* Define to 1 if you have the declaration of `IPPROTO_TCP', and to 0 if you
+   don't. */
+#define HAVE_DECL_IPPROTO_TCP 1
+
+/* Define to 1 if you have the declaration of `IPV6_V6ONLY', and to 0 if you
+   don't. */
+#define HAVE_DECL_IPV6_V6ONLY 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `gai_strerror' function. */
+/* #undef HAVE_GAI_STRERROR */
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#define HAVE_GETADDRINFO 1
+
+/* Define to 1 if you have the `gethostent' function. */
+/* #undef HAVE_GETHOSTENT */
+
+/* Define to 1 if you have getpeereid. */
+/* #undef HAVE_GETPEEREID */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if in_addr_t is available. */
+/* #undef HAVE_IN_ADDR_T */
+
+/* Define to 1 if you have the `ws2_32' library (-lws2_32). */
+#define HAVE_LIBWS2_32 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have a Linux sendfile(2) implementation. */
+/* #undef HAVE_LINUX_SENDFILE */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+/* #undef HAVE_NETINET_IN_H */
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+/* #undef HAVE_NETINET_TCP_H */
+
+/* Define to 1 if you have the `readlink' function. */
+/* #undef HAVE_READLINK */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if `msg_accrights' is a member of `struct msghdr'. */
+/* #undef HAVE_STRUCT_MSGHDR_MSG_ACCRIGHTS */
+
+/* Define to 1 if `msg_control' is a member of `struct msghdr'. */
+/* #undef HAVE_STRUCT_MSGHDR_MSG_CONTROL */
+
+/* Define to 1 if `sa_len' is a member of `struct sockaddr'. */
+/* #undef HAVE_STRUCT_SOCKADDR_SA_LEN */
+
+/* Define to 1 if you have both SO_PEERCRED and struct ucred. */
+/* #undef HAVE_STRUCT_UCRED */
+
+/* Define to 1 if you have the `symlink' function. */
+/* #undef HAVE_SYMLINK */
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+/* #undef HAVE_SYS_SOCKET_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+/* #undef HAVE_SYS_UIO_H */
+
+/* Define to 1 if you have the <sys/un.h> header file. */
+/* #undef HAVE_SYS_UN_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <winsock2.h> header file. */
+#define HAVE_WINSOCK2_H 1
+
+/* Define to 1 if you have the <ws2tcpip.h> header file. */
+#define HAVE_WS2TCPIP_H 1
+
+/* Define to 1 if the `getaddrinfo' function needs WINVER set. */
+#define NEED_WINVER_XP 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "libraries@haskell.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "Haskell network package"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "Haskell network package 2.3.0.14"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "network"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.3.0.14"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */

--- a/network.cabal
+++ b/network.cabal
@@ -14,7 +14,7 @@ extra-tmp-files:
 extra-source-files:
   README.md examples/*.hs tests/*.hs config.guess config.sub install-sh
   configure.ac configure network.buildinfo.in
-  include/HsNetworkConfig.h.in include/HsNet.h
+  include/HsNetworkConfig.h.in include/HsNet.h include/HsNetworkConfigWin.h
   -- C sources only used on some systems
   cbits/ancilData.c cbits/asyncAccept.c cbits/initWinSock.c
   cbits/winSockErr.c
@@ -39,15 +39,17 @@ library
       Network.Socket.ByteString.IOVec
       Network.Socket.ByteString.Lazy.Posix
       Network.Socket.ByteString.MsgHdr
-  if os(windows)
+    install-includes: HsNetworkConfig.h
+  else
     other-modules:
       Network.Socket.ByteString.Lazy.Windows
 	-- fixed configuration on Windows without MSYS
 	-- todo: actually detect MSYS here
-    cpp-options: -DCALLCONV=stdcall -DWINVER=0x0501 
-    cc-options: -DCALLCONV=stdcall -DWINVER=0x0501 
+    cpp-options: -DCALLCONV=stdcall -DWINVER=0x0501 -DBUILDING_ON_WINDOWS
+    cc-options: -DCALLCONV=stdcall -DWINVER=0x0501 -DBUILDING_ON_WINDOWS
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
     extra-libraries: ws2_32 	
+    install-includes: HsNetworkConfigWin.h
 
   build-depends:
     base >= 3 && < 5,
@@ -62,7 +64,7 @@ library
     CPP, DeriveDataTypeable, ForeignFunctionInterface, TypeSynonymInstances
   include-dirs: include
   includes: HsNet.h
-  install-includes: HsNet.h HsNetworkConfig.h
+  install-includes: HsNet.h
   c-sources: cbits/HsNet.c
   ghc-options: -Wall -fwarn-tabs
 

--- a/network.cabal
+++ b/network.cabal
@@ -6,7 +6,7 @@ maintainer:     Johan Tibell <johan.tibell@gmail.com>
 synopsis:       Low-level networking interface
 description:    Low-level networking interface
 category:       Network
-build-type:     Configure
+build-type:     Custom
 cabal-version:  >=1.8
 extra-tmp-files:
   config.log config.status autom4te.cache network.buildinfo
@@ -42,6 +42,12 @@ library
   if os(windows)
     other-modules:
       Network.Socket.ByteString.Lazy.Windows
+	-- fixed configuration on Windows without MSYS
+	-- todo: actually detect MSYS here
+    cpp-options: -DCALLCONV=stdcall -DWINVER=0x0501 
+    cc-options: -DCALLCONV=stdcall -DWINVER=0x0501 
+    c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
+    extra-libraries: ws2_32 	
 
   build-depends:
     base >= 3 && < 5,
@@ -103,4 +109,4 @@ test-suite uri
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/network.git
+  location: git://github.com/tener/network.git

--- a/network.cabal
+++ b/network.cabal
@@ -111,4 +111,4 @@ test-suite uri
 
 source-repository head
   type:     git
-  location: git://github.com/tener/network.git
+  location: git://github.com/haskell/network.git


### PR DESCRIPTION
MSYS requirement to build network package on Windows is a burden to end users. After reading a [proposal](http://www.haskell.org/pipermail/libraries/2014-August/023458.html) motivated by this problem, I took some time to implement a proof-of-concept system of installation for Windows users without MSYS.

The idea is to run the build with MSYS and then extract the options passed to GHC as well as created headers file into a standalone build that can be executed without MSYS.

This is likely not in a shape to be included in a master repo but it may be a start of the feature described above.
