### PR TITLE
Resolve broken imports on Windows

### DIFF
--- a/Network/Socket/ByteString.hsc
+++ b/Network/Socket/ByteString.hsc
@@ -73,7 +73,6 @@ import Network.Socket.ByteString.MsgHdr (MsgHdr(..))
 
 #else
 import GHC.IO.FD
-import GHC.Handle (readRawBufferPtr, writeRawBufferPtr)
 #endif
 
 #if !defined(mingw32_HOST_OS)


### PR DESCRIPTION
Commit b5affca26b8a65a54dde7271de4479b6f01db595 removes support for GHC versions less than 7.0, but it looks like `Network.Socket.ByteString` still attempts to import `readRawBufferPtr` and `writeRawBufferPtr` from `GHC.Handle` on Windows, even though it's now located in `GHC.IO.FD`. This commit simply removes the `GHC.Handle` import so that `network` will build correctly on Windows.
