### PR TITLE
use winsock library when configured in an MSYS2 environment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ AC_CHECK_FUNCS(gethostent)
 AC_CHECK_FUNCS(accept4)
 
 case "$host" in
-*-mingw*)
+*-mingw* | *-msys*)
 	EXTRA_SRCS="cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c"
 	EXTRA_LIBS=ws2_32
 	CALLCONV=stdcall ;;


### PR DESCRIPTION
I'm not too familiar with the ins and outs of autotools (is anyone?), but this makes the package work here.

The installation is the recommended setup for building GHC on Windows, according to the GHC wiki: https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Windows

My environment is the MSYS2 shell on i686, with the `ghc/bin` and `ghc/mingw/bin` directories in `$PATH` before MSYS2's own bin dir. `which gcc` gives the GHC gcc.

Autotools installed via pacman, as per the GHC wiki instructions. The configure script reports the build system as `i686-pc-msys`. This patch changes the configure script to treat this as a winsock platform.
