### PR TITLE
Remove most/all requirements for withSocketsDo on Windows

### DIFF
--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -534,7 +534,7 @@ foreign import CALLCONV safe "if_nametoindex"
 
 {-# NOINLINE lock #-}
 lock :: MVar ()
-lock = unsafePerformIO $ newMVar ()
+lock = unsafePerformIO $ withSocketsDo $ newMVar ()
 
 withLock :: IO a -> IO a
 withLock act = withMVar lock (\_ -> act)

--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -179,7 +179,7 @@ getServiceByName name proto = withLock $ do
  withCString name  $ \ cstr_name  -> do
  withCString proto $ \ cstr_proto -> do
  throwNoSuchThingIfNull "getServiceByName" "no such service entry"
-   $ (trySysCall (c_getservbyname cstr_name cstr_proto))
+   $ c_getservbyname cstr_name cstr_proto
  >>= peek
 
 foreign import CALLCONV unsafe "getservbyname"
@@ -190,7 +190,7 @@ getServiceByPort :: PortNumber -> ProtocolName -> IO ServiceEntry
 getServiceByPort (PortNum port) proto = withLock $ do
  withCString proto $ \ cstr_proto -> do
  throwNoSuchThingIfNull "getServiceByPort" "no such service entry"
-   $ (trySysCall (c_getservbyport (fromIntegral port) cstr_proto))
+   $ c_getservbyport (fromIntegral port) cstr_proto
  >>= peek
 
 foreign import CALLCONV unsafe "getservbyport"
@@ -206,18 +206,18 @@ getServicePortNumber name = do
 getServiceEntry :: IO ServiceEntry
 getServiceEntry = withLock $ do
  throwNoSuchThingIfNull "getServiceEntry" "no such service entry"
-   $ trySysCall c_getservent
+   $ c_getservent
  >>= peek
 
 foreign import ccall unsafe "getservent" c_getservent :: IO (Ptr ServiceEntry)
 
 setServiceEntry :: Bool -> IO ()
-setServiceEntry flg = withLock $ trySysCall $ c_setservent (fromBool flg)
+setServiceEntry flg = withLock $ c_setservent (fromBool flg)
 
 foreign import ccall unsafe  "setservent" c_setservent :: CInt -> IO ()
 
 endServiceEntry :: IO ()
-endServiceEntry = withLock $ trySysCall $ c_endservent
+endServiceEntry = withLock $ c_endservent
 
 foreign import ccall unsafe  "endservent" c_endservent :: IO ()
 
@@ -276,7 +276,7 @@ getProtocolByName :: ProtocolName -> IO ProtocolEntry
 getProtocolByName name = withLock $ do
  withCString name $ \ name_cstr -> do
  throwNoSuchThingIfNull "getProtocolByName" ("no such protocol name: " ++ name)
-   $ (trySysCall.c_getprotobyname) name_cstr
+   $ c_getprotobyname name_cstr
  >>= peek
 
 foreign import  CALLCONV unsafe  "getprotobyname"
@@ -286,7 +286,7 @@ foreign import  CALLCONV unsafe  "getprotobyname"
 getProtocolByNumber :: ProtocolNumber -> IO ProtocolEntry
 getProtocolByNumber num = withLock $ do
  throwNoSuchThingIfNull "getProtocolByNumber" ("no such protocol number: " ++ show num)
-   $ (trySysCall.c_getprotobynumber) (fromIntegral num)
+   $ c_getprotobynumber (fromIntegral num)
  >>= peek
 
 foreign import CALLCONV unsafe  "getprotobynumber"
@@ -302,18 +302,18 @@ getProtocolNumber proto = do
 getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
 getProtocolEntry = withLock $ do
  ent <- throwNoSuchThingIfNull "getProtocolEntry" "no such protocol entry"
-                $ trySysCall c_getprotoent
+                $ c_getprotoent
  peek ent
 
 foreign import ccall unsafe  "getprotoent" c_getprotoent :: IO (Ptr ProtocolEntry)
 
 setProtocolEntry :: Bool -> IO ()       -- Keep DB Open ?
-setProtocolEntry flg = withLock $ trySysCall $ c_setprotoent (fromBool flg)
+setProtocolEntry flg = withLock $ c_setprotoent (fromBool flg)
 
 foreign import ccall unsafe "setprotoent" c_setprotoent :: CInt -> IO ()
 
 endProtocolEntry :: IO ()
-endProtocolEntry = withLock $ trySysCall $ c_endprotoent
+endProtocolEntry = withLock $ c_endprotoent
 
 foreign import ccall unsafe "endprotoent" c_endprotoent :: IO ()
 
@@ -377,7 +377,7 @@ getHostByName :: HostName -> IO HostEntry
 getHostByName name = withLock $ do
   withCString name $ \ name_cstr -> do
    ent <- throwNoSuchThingIfNull "getHostByName" "no such host entry"
-                $ trySysCall $ c_gethostbyname name_cstr
+                $ c_gethostbyname name_cstr
    peek ent
 
 foreign import CALLCONV safe "gethostbyname"
@@ -391,7 +391,7 @@ getHostByAddr :: Family -> HostAddress -> IO HostEntry
 getHostByAddr family addr = do
  with addr $ \ ptr_addr -> withLock $ do
  throwNoSuchThingIfNull         "getHostByAddr" "no such host entry"
-   $ trySysCall $ c_gethostbyaddr ptr_addr (fromIntegral (sizeOf addr)) (packFamily family)
+   $ c_gethostbyaddr ptr_addr (fromIntegral (sizeOf addr)) (packFamily family)
  >>= peek
 
 foreign import CALLCONV safe "gethostbyaddr"
@@ -401,13 +401,13 @@ foreign import CALLCONV safe "gethostbyaddr"
 getHostEntry :: IO HostEntry
 getHostEntry = withLock $ do
  throwNoSuchThingIfNull         "getHostEntry" "unable to retrieve host entry"
-   $ trySysCall $ c_gethostent
+   $ c_gethostent
  >>= peek
 
 foreign import ccall unsafe "gethostent" c_gethostent :: IO (Ptr HostEntry)
 
 setHostEntry :: Bool -> IO ()
-setHostEntry flg = withLock $ trySysCall $ c_sethostent (fromBool flg)
+setHostEntry flg = withLock $ c_sethostent (fromBool flg)
 
 foreign import ccall unsafe "sethostent" c_sethostent :: CInt -> IO ()
 
@@ -468,7 +468,7 @@ getNetworkByName :: NetworkName -> IO NetworkEntry
 getNetworkByName name = withLock $ do
  withCString name $ \ name_cstr -> do
   throwNoSuchThingIfNull "getNetworkByName" "no such network entry"
-    $ trySysCall $ c_getnetbyname name_cstr
+    $ c_getnetbyname name_cstr
   >>= peek
 
 foreign import ccall unsafe "getnetbyname"
@@ -477,7 +477,7 @@ foreign import ccall unsafe "getnetbyname"
 getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
 getNetworkByAddr addr family = withLock $ do
  throwNoSuchThingIfNull "getNetworkByAddr" "no such network entry"
-   $ trySysCall $ c_getnetbyaddr addr (packFamily family)
+   $ c_getnetbyaddr addr (packFamily family)
  >>= peek
 
 foreign import ccall unsafe "getnetbyaddr"
@@ -486,7 +486,7 @@ foreign import ccall unsafe "getnetbyaddr"
 getNetworkEntry :: IO NetworkEntry
 getNetworkEntry = withLock $ do
  throwNoSuchThingIfNull "getNetworkEntry" "no more network entries"
-          $ trySysCall $ c_getnetent
+          $ c_getnetent
  >>= peek
 
 foreign import ccall unsafe "getnetent" c_getnetent :: IO (Ptr NetworkEntry)
@@ -495,13 +495,13 @@ foreign import ccall unsafe "getnetent" c_getnetent :: IO (Ptr NetworkEntry)
 -- whether a connection is maintained open between various
 -- networkEntry calls
 setNetworkEntry :: Bool -> IO ()
-setNetworkEntry flg = withLock $ trySysCall $ c_setnetent (fromBool flg)
+setNetworkEntry flg = withLock $ c_setnetent (fromBool flg)
 
 foreign import ccall unsafe "setnetent" c_setnetent :: CInt -> IO ()
 
 -- | Close the connection to the network name database.
 endNetworkEntry :: IO ()
-endNetworkEntry = withLock $ trySysCall $ c_endnetent
+endNetworkEntry = withLock $ c_endnetent
 
 foreign import ccall unsafe "endnetent" c_endnetent :: IO ()
 
@@ -570,9 +570,6 @@ getEntries getOne atEnd = loop
         Nothing -> return []
         Just v  -> loop >>= \ vs -> atEnd >> return (v:vs)
 
-
-trySysCall :: IO a -> IO a
-trySysCall act = act
 
 throwNoSuchThingIfNull :: String -> String -> IO (Ptr a) -> IO (Ptr a)
 throwNoSuchThingIfNull loc desc act = do

--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -581,11 +581,7 @@ trySysCall :: IO a -> IO a
 trySysCall act = act
 #else
 trySysCall :: IO (Ptr a) -> IO (Ptr a)
-trySysCall act = do
-  ptr <- act
-  if (ptr == nullPtr)
-   then withSocketsDo act
-   else return ptr
+trySysCall act = act
 #endif
 
 throwNoSuchThingIfNull :: String -> String -> IO (Ptr a) -> IO (Ptr a)

--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -571,18 +571,8 @@ getEntries getOne atEnd = loop
         Just v  -> loop >>= \ vs -> atEnd >> return (v:vs)
 
 
--- ---------------------------------------------------------------------------
--- Winsock only:
---   The BSD API networking calls made locally return NULL upon failure.
---   That failure may very well be due to WinSock not being initialised,
---   so if NULL is seen try init'ing and repeat the call.
-#if !defined(mingw32_HOST_OS) && !defined(_WIN32)
 trySysCall :: IO a -> IO a
 trySysCall act = act
-#else
-trySysCall :: IO (Ptr a) -> IO (Ptr a)
-trySysCall act = act
-#endif
 
 throwNoSuchThingIfNull :: String -> String -> IO (Ptr a) -> IO (Ptr a)
 throwNoSuchThingIfNull loc desc act = do

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -391,7 +391,7 @@ bind (MkSocket s _family _stype _protocol socketStatus) addr = do
 connect :: Socket    -- Unconnected Socket
         -> SockAddr  -- Socket address stuff
         -> IO ()
-connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = do
+connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = withSocketsDo $ do
  modifyMVar_ socketStatus $ \currentStatus -> do
  if currentStatus /= NotConnected && currentStatus /= Bound
   then
@@ -412,15 +412,7 @@ connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = do
 --                   _ | err == eAGAIN      -> connectBlocked
                      _otherwise             -> throwSocketError "connect"
 #else
-                   rc <- c_getLastError
-                   case rc of
-                     #{const WSANOTINITIALISED} -> do
-                       withSocketsDo (return ())
-                       r <- c_connect s p_addr (fromIntegral sz)
-                       if r == -1
-                         then throwSocketError "connect"
-                         else return ()
-                     _ -> throwSocketError "connect"
+                   throwSocketError "connect"
 #endif
                else return ()
 

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -256,6 +256,7 @@ mkSocket :: CInt
          -> IO Socket
 mkSocket fd fam sType pNum stat = do
    mStat <- newMVar stat
+   withSocketsDo $ return ()
    return (MkSocket fd fam sType pNum mStat)
 
 
@@ -313,6 +314,7 @@ socket family stype protocol = do
                 c_socket (packFamily family) c_stype protocol
     setNonBlockIfNeeded fd
     socket_status <- newMVar NotConnected
+    withSocketsDo $ return ()
     let sock = MkSocket fd family stype protocol socket_status
 #if HAVE_DECL_IPV6_V6ONLY
 # if defined(mingw32_HOST_OS)
@@ -348,6 +350,7 @@ socketPair family stype protocol = do
     mkNonBlockingSocket fd = do
        setNonBlockIfNeeded fd
        stat <- newMVar Connected
+       withSocketsDo $ return ()
        return (MkSocket fd family stype protocol stat)
 
 foreign import ccall unsafe "socketpair"
@@ -1126,7 +1129,7 @@ isAcceptable (MkSocket _ _ _ _ status) = do
 -- Internet address manipulation routines:
 
 inet_addr :: String -> IO HostAddress
-inet_addr ipstr = do
+inet_addr ipstr = withSocketsDo $ do
    withCString ipstr $ \str -> do
    had <- c_inet_addr str
    if had == -1
@@ -1134,7 +1137,7 @@ inet_addr ipstr = do
     else return had  -- network byte order
 
 inet_ntoa :: HostAddress -> IO String
-inet_ntoa haddr = do
+inet_ntoa haddr = withSocketsDo $ do
   pstr <- c_inet_ntoa haddr
   peekCString pstr
 
@@ -1402,7 +1405,7 @@ getAddrInfo :: Maybe AddrInfo -- ^ preferred socket type or protocol
             -> Maybe ServiceName -- ^ service name to look up
             -> IO [AddrInfo] -- ^ resolved addresses, with "best" first
 
-getAddrInfo hints node service =
+getAddrInfo hints node service = withSocketsDo $
   maybeWith withCString node $ \c_node ->
     maybeWith withCString service $ \c_service ->
       maybeWith with filteredHints $ \c_hints ->
@@ -1507,7 +1510,7 @@ getNameInfo :: [NameInfoFlag] -- ^ flags to control lookup behaviour
             -> SockAddr -- ^ the address to look up
             -> IO (Maybe HostName, Maybe ServiceName)
 
-getNameInfo flags doHost doService addr =
+getNameInfo flags doHost doService addr = withSocketsDo $
   withCStringIf doHost (#const NI_MAXHOST) $ \c_hostlen c_host ->
     withCStringIf doService (#const NI_MAXSERV) $ \c_servlen c_serv -> do
       withSockAddr addr $ \ptr_addr sz -> do

--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -253,9 +253,8 @@ withSocketsDo act = do
     x <- initWinSock
     if x /= 0
        then ioError (userError "Failed to initialise WinSock")
-       else act `finally` shutdownWinSock
+       else act
 
 foreign import ccall unsafe "initWinSock" initWinSock :: IO Int
-foreign import ccall unsafe "shutdownWinSock" shutdownWinSock :: IO ()
 
 #endif

--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -237,15 +237,19 @@ throwSocketErrorWaitWrite sock name io =
 -- ---------------------------------------------------------------------------
 -- WinSock support
 
-{-| On Windows operating systems, the networking subsystem has to be
-initialised using 'withSocketsDo' before any networking operations can
-be used.  eg.
+{-| With older versions of the @network@ library on Windows operating systems,
+the networking subsystem must be initialised using 'withSocketsDo' before
+any networking operations can be used. eg.
 
 > main = withSocketsDo $ do {...}
 
-Although this is only strictly necessary on Windows platforms, it is
-harmless on other platforms, so for portability it is good practice to
-use it all the time.
+It is fine to nest calls to 'withSocketsDo', and to perform networking operations
+after 'withSocketsDo' has returned.
+
+In newer versions of the @network@ library it is only necessary to call
+'withSocketsDo' if you are calling the 'MkSocket' constructor directly.
+However, for compatibility with older versions on Windows, it is good practice
+to always call 'withSocketsDo' (it's very cheap).
 -}
 {-# INLINE withSocketsDo #-}
 withSocketsDo :: IO a -> IO a

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -74,6 +74,9 @@ import Foreign.Storable
 --   * Socket type
 --   * Protocol number
 --   * Status flag
+--
+--   If you are calling the 'MkSocket' constructor directly you should ensure
+--   you have called 'Network.withSocketsDo'.
 data Socket
   = MkSocket
             CInt                 -- File Descriptor

--- a/cbits/initWinSock.c
+++ b/cbits/initWinSock.c
@@ -4,7 +4,12 @@
 #if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
 
 static int winsock_inited = 0;
-static int winsock_uninited = 0;
+
+static void
+shutdownHandler(void)
+{
+  WSACleanup();
+}
 
 /* Initialising WinSock... */
 int
@@ -29,24 +34,10 @@ initWinSock ()
       return (-1);
     }
 
+    atexit(shutdownHandler);
     winsock_inited = 1;
   }
   return 0;
-}
-
-static void
-shutdownHandler(void)
-{
-  WSACleanup();
-}
-
-void
-shutdownWinSock()
-{
-    if (!winsock_uninited) {
-	atexit(shutdownHandler);
-	winsock_uninited = 1;
-    }
 }
 
 #endif

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -44,7 +44,6 @@
 #  define IPV6_V6ONLY 27
 # endif
 
-extern void  shutdownWinSock();
 extern int   initWinSock ();
 extern const char* getWSErrorDescr(int err);
 extern void* newAcceptParams(int sock,


### PR DESCRIPTION
This patch tries to eliminate the need to call `withSocketsDo` on Windows. While I can't guarantee that it's never required, it certainly fixes some cases (e.g. [the one I hit most recently](https://github.com/snoyberg/http-client/issues/94#issuecomment-70209111) with http-client by @snoyberg), and I believe probably fixes most if-not-all cases. There are three patches:

* Simplify `withSocketsDo`, so there is no afterwards action. The afterwards action called `atexit` anyway, so was pretty pointless to delay. (In reality, the `atexit` action is probably totally useless, but I'll leave it for now, since it isn't harmful either.)
* Make `withSocketsDo` cheaper by using a Haskell-side CAF to avoid repeat initialization. Now an unnecessary `withSocketsDo` on Linux is free, and on Windows is a few instructions, so they can be placed everywhere.
* Add `withSocketsDo` at all the reasonable entry points. The logic I used is to add them just before creating `MkSocket`, and to those functions which call the C library but don't require a socket, e.g. `getAddrInfo`.

I note that Sigbjorn Finne in 2003 tried to eliminate the need to call `withSocketsDo` using two tricks:

* The `trySysCall` function retries with `withSocketsDo` if the answer is a null pointer.
* If some functions return an error code of `WSANOTINITIALISED` then they are retried.

I now believe all the Sigbjorn's calls are redundant - but they're very cheap and can only help, so I've left them.

CC @fegu, who was brainstorming ideas with me.