### PR TITLE
Suppress setSocketOption IPv6Only errors on all platforms

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -320,14 +320,11 @@ socket family stype protocol = do
     withSocketsDo $ return ()
     let sock = MkSocket fd family stype protocol socket_status
 #if HAVE_DECL_IPV6_V6ONLY
-# if defined(mingw32_HOST_OS)
-    -- the IPv6Only option is only supported on Windows Vista and later,
-    -- so trying to change it might throw an error
+    -- changing the IPv6Only option does not work with all parameters,
+    -- and it is not supported on versions of Windows earlier than Vista,
+    -- so suppress any errors thrown
     when (family == AF_INET6) $
             E.catch (setSocketOption sock IPv6Only 0) $ (\(_ :: E.IOException) -> return ())
-# else
-    when (family == AF_INET6) $ setSocketOption sock IPv6Only 0
-# endif
 #endif
     return sock
 

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -305,8 +305,9 @@ instance Show SockAddr where
 -- and protocol number.  The address family is usually 'AF_INET',
 -- 'AF_INET6', or 'AF_UNIX'.  The socket type is usually 'Stream' or
 -- 'Datagram'.  The protocol number is usually 'defaultProtocol'.
--- If 'AF_INET6' is used, the 'IPv6Only' socket option is set to 0
--- so that both IPv4 and IPv6 can be handled with one socket.
+-- If 'AF_INET6' is used and the socket type is 'Stream' or 'Datagram',
+-- the 'IPv6Only' socket option is set to 0 so that both IPv4 and IPv6
+-- can be handled with one socket.
 socket :: Family         -- Family Name (usually AF_INET)
        -> SocketType     -- Socket Type (usually Stream)
        -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)


### PR DESCRIPTION
This is the simple fix for #180, which changes `socket` to suppress `setSocketOption` errors on all platforms.