### PR TITLE
Update documentation for `close`, `send` and `recv`

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -309,8 +309,8 @@ accept (MkSocket _ family _ _ _) =
   error $ "Sorry, address family " ++ (show family) ++ " is not supported!"
 
 
--- | Close the socket. All future operations on the socket object will fail.
---   The remote end will receive no more data (after queued data is flushed).
+-- | Close the socket. Sending data to or receiving data from closed socket
+-- may lead to undefined behaviour.
 sClose :: Socket -> IO ()
 sClose = close -- Explicit redefinition because Network.sClose is deperecated,
                -- hence the re-export would also be marked as such.

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -632,6 +632,8 @@ recvBufFrom sock@(MkSocket s family _stype _protocol _status) ptr nbytes
 -- | Send data to the socket. The socket must be connected to a remote
 -- socket. Returns the number of bytes sent.  Applications are
 -- responsible for ensuring that all data has been sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 send :: Socket  -- Bound/Connected Socket
      -> String  -- Data to send
      -> IO Int  -- Number of Bytes sent
@@ -653,6 +655,8 @@ send sock@(MkSocket s _family _stype _protocol _status) xs = do
 -- | Send data to the socket. The socket must be connected to a remote
 -- socket. Returns the number of bytes sent.  Applications are
 -- responsible for ensuring that all data has been sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendBuf :: Socket     -- Bound/Connected Socket
         -> Ptr Word8  -- Pointer to the data to send
         -> Int        -- Length of the buffer
@@ -683,6 +687,8 @@ sendBuf sock@(MkSocket s _family _stype _protocol _status) str len = do
 --
 -- For TCP sockets, a zero length return value means the peer has
 -- closed its half side of the connection.
+--
+-- Receiving data from closed socket may lead to undefined behaviour.
 recv :: Socket -> Int -> IO String
 recv sock l = recvLen sock l >>= \ (s,_) -> return s
 
@@ -717,6 +723,8 @@ recvLen sock@(MkSocket s _family _stype _protocol _status) nbytes
 --
 -- For TCP sockets, a zero length return value means the peer has
 -- closed its half side of the connection.
+--
+-- Receiving data from closed socket may lead to undefined behaviour.
 recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
 recvBuf sock p l = recvLenBuf sock p l
 
@@ -1083,9 +1091,8 @@ shutdown (MkSocket s _ _ _ _) stype = do
 
 -- -----------------------------------------------------------------------------
 
--- | Close the socket.  All future operations on the socket object
--- will fail.  The remote end will receive no more data (after queued
--- data is flushed).
+-- | Close the socket. Sending data to or receiving data from closed socket
+-- may lead to undefined behaviour.
 close :: Socket -> IO ()
 close (MkSocket s _ _ _ socketStatus) = do
  modifyMVar_ socketStatus $ \ status ->

--- a/Network/Socket/ByteString.hsc
+++ b/Network/Socket/ByteString.hsc
@@ -88,6 +88,8 @@ foreign import CALLCONV unsafe "recv"
 -- | Send data to the socket.  The socket must be connected to a
 -- remote socket.  Returns the number of bytes sent. Applications are
 -- responsible for ensuring that all data has been sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 send :: Socket      -- ^ Connected socket
      -> ByteString  -- ^ Data to send
      -> IO Int      -- ^ Number of bytes sent
@@ -107,6 +109,8 @@ send sock@(MkSocket s _ _ _ _) xs =
 -- until either all data has been sent or an error occurs.  On error,
 -- an exception is raised, and there is no way to determine how much
 -- data, if any, was successfully sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendAll :: Socket      -- ^ Connected socket
         -> ByteString  -- ^ Data to send
         -> IO ()
@@ -118,6 +122,8 @@ sendAll sock bs = do
 -- explicitly, so the socket need not be in a connected state.
 -- Returns the number of bytes sent. Applications are responsible for
 -- ensuring that all data has been sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendTo :: Socket      -- ^ Socket
        -> ByteString  -- ^ Data to send
        -> SockAddr    -- ^ Recipient address
@@ -131,6 +137,8 @@ sendTo sock xs addr =
 -- data has been sent or an error occurs.  On error, an exception is
 -- raised, and there is no way to determine how much data, if any, was
 -- successfully sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendAllTo :: Socket      -- ^ Socket
           -> ByteString  -- ^ Data to send
           -> SockAddr    -- ^ Recipient address
@@ -167,6 +175,8 @@ sendAllTo sock xs addr = do
 -- sent or an error occurs.  On error, an exception is raised, and
 -- there is no way to determine how much data, if any, was
 -- successfully sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendMany :: Socket        -- ^ Connected socket
          -> [ByteString]  -- ^ Data to send
          -> IO ()
@@ -190,6 +200,8 @@ sendMany sock = sendAll sock . B.concat
 -- continues to send data until either all data has been sent or an
 -- error occurs.  On error, an exception is raised, and there is no
 -- way to determine how much data, if any, was successfully sent.
+--
+-- Sending data to closed socket may lead to undefined behaviour.
 sendManyTo :: Socket        -- ^ Socket
            -> [ByteString]  -- ^ Data to send
            -> SockAddr      -- ^ Recipient address
@@ -226,6 +238,8 @@ sendManyTo sock cs = sendAllTo sock (B.concat cs)
 --
 -- For TCP sockets, a zero length return value means the peer has
 -- closed its half side of the connection.
+--
+-- Receiving data from closed socket may lead to undefined behaviour.
 recv :: Socket         -- ^ Connected socket
      -> Int            -- ^ Maximum number of bytes to receive
      -> IO ByteString  -- ^ Data received
@@ -249,6 +263,8 @@ recvInner sock nbytes ptr =
 -- connected state.  Returns @(bytes, address)@ where @bytes@ is a
 -- 'ByteString' representing the data received and @address@ is a
 -- 'SockAddr' representing the address of the sending socket.
+--
+-- Receiving data from closed socket may lead to undefined behaviour.
 recvFrom :: Socket                     -- ^ Socket
          -> Int                        -- ^ Maximum number of bytes to receive
          -> IO (ByteString, SockAddr)  -- ^ Data received and sender address

--- a/Network/Socket/ByteString/Lazy.hs
+++ b/Network/Socket/ByteString/Lazy.hs
@@ -77,6 +77,8 @@ getContents sock = loop where
 -- until a message arrives.
 --
 -- If there is no more data to be received, returns an empty 'ByteString'.
+--
+-- Receiving data from closed socket may lead to undefined behaviour.
 recv :: Socket         -- ^ Connected socket
      -> Int64          -- ^ Maximum number of bytes to receive
      -> IO ByteString  -- ^ Data received


### PR DESCRIPTION
Add a note that sending data to or receiving data from closed
socket in unsafe. See #169 

I'd prefer to fix the implementation instead, but it is not trivial and requires deeper knowledges of the code base. Fixing the documentation is definitely better then doing nothing. 