### PR TITLE
Check socket status before writing/reading to/from it

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -49,6 +49,7 @@ module Network.Socket.Types
     -- * Unsorted
     , ProtocolNumber
     , PortNumber(..)
+    , SocketClosed (..)
 
     -- * Low-level helpers
     , zeroMemory
@@ -56,6 +57,7 @@ module Network.Socket.Types
 
 import Control.Concurrent.MVar
 import Control.Monad
+import Control.Exception (Exception)
 import Data.Bits
 import Data.Maybe
 import Data.Ratio
@@ -125,6 +127,12 @@ data SocketStatus
   | ConvertedToHandle   -- ^ Is now a 'Handle' (via 'socketToHandle'), don't touch
   | Closed              -- ^ Closed was closed by 'close'
     deriving (Eq, Show, Typeable)
+
+-- | Exception thrown when reading from or writing to closed socket
+data SocketClosed = SocketClosed
+   deriving (Show, Eq, Typeable)
+
+instance Exception SocketClosed
 
 -----------------------------------------------------------------------------
 -- Socket types


### PR DESCRIPTION
It is unsafe to write or read to closed FD because OS is free
to reuse it, so it may lead to writing to some other destination.
See #169

I decided to check status each time the FD becomes ready. It introduces bigger overhead, but at least it doesn't change the semantics. Though there is a chance that closed FD is registered in event manager queue, I'm not sure how bad it is.