### PR TITLE
Work around GHC bug #12020

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -105,8 +105,8 @@ test-suite regression
     network,
     test-framework,
     test-framework-hunit
-
-  ghc-options: -Wall
+  -- Some of the bugs only occur in the threaded RTS
+  ghc-options: -Wall -threaded
 
 test-suite doctest
   hs-source-dirs: tests


### PR DESCRIPTION
This PR tries to work around [GHC bug #12010](https://ghc.haskell.org/trac/ghc/ticket/12010#ticket), where calls to `readRawBufferPtr` and `writeRawBufferPtr` fail to throw exceptions on Windows 64 bit. I wrote tests, and patched `recvBuf` and `sendBuf` to make them pass. Unfortunately, I can still get a segfault on my outside test with artificial network corruption some of the time - somewhere less than 1.5%. The test program downloads a small package from FP Complete's Hackage mirror over TLS. If anyone can explain it, I'd be grateful. If not, this PR makes the crash much more rare anyway.

To reproduce the crash:
- be on a Windows 64 bit machine with Stack
- `git clone -b network-pr https://github.com/enolan/http-conduit-crash-hang.git`
- `git clone https://github.com/enolan/findcrash.git`
- `stack build` both of those
- get [Clumsy](https://jagt.github.io/clumsy/) and set it to tamper at 20%
- run `findcrash` with the location of `bad-memcpy-crash` from the `http-conduit-crash-hang` repo as its argument and wait a bit. It'll run the program until it crashes or 200 times, whichever comes first.

You should get the Windows dialog box for a segfault: "bad-memcpy-crash.exe has stopped working".

Here's what I know:
- Unlike the original bug, it doesn't follow a failed call to `recv` or `send`. It's either a new bug I introduced when I fixed the first one, or was always there.
- It doesn't happen inside of a Windows library function
- Turning on RTS sanity checking doesn't help
- It happens regardless of whether the threaded RTS is on or not
- It's rarer when the threaded RTS is off
- It seems to happen between calls to `recv`, not during them. I've only seen it happen after TLS handshaking was done, but that may be chance.

I hope a fresh set of eyes sees something. Maybe in the refactoring.

Best,
Echo