### PR TITLE
Remove dead occurrences of cygwin32_HOST_OS.

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -80,7 +80,7 @@ import qualified Control.Exception as Exception
 data PortID =
           Service String                -- Service Name eg "ftp"
         | PortNumber PortNumber         -- User defined Port Number
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
         | UnixSocket String             -- Unix family socket in file system
 #endif
         deriving (Show, Eq)
@@ -127,7 +127,7 @@ connectTo hostname (PortNumber port) = do
         )
 #endif
 
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 connectTo _ (UnixSocket path) = do
     bracketOnError
         (socket AF_UNIX Stream 0)
@@ -213,7 +213,7 @@ listenOn (PortNumber port) = do
         )
 #endif
 
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 listenOn (UnixSocket path) =
     bracketOnError
         (socket AF_UNIX Stream 0)
@@ -289,7 +289,7 @@ accept sock@(MkSocket _ AF_INET6 _ _ _) = do
          \_ -> case addr of
                  SockAddrInet  _   a   -> inet_ntoa a
                  SockAddrInet6 _ _ a _ -> return (show a)
-# if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+# if !defined(mingw32_HOST_OS)
                  SockAddrUnix      a   -> return a
 # endif
  handle <- socketToHandle sock' ReadWriteMode
@@ -299,7 +299,7 @@ accept sock@(MkSocket _ AF_INET6 _ _ _) = do
               _                     -> -1
  return (handle, peer, port)
 #endif
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 accept sock@(MkSocket _ AF_UNIX _ _ _) = do
  ~(sock', (SockAddrUnix path)) <- Socket.accept sock
  handle <- socketToHandle sock' ReadWriteMode
@@ -400,7 +400,7 @@ socketPort s = do
 #if defined(IPV6_SOCKET_SUPPORT)
      SockAddrInet6 port _ _ _ -> PortNumber port
 #endif
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
      SockAddrUnix path        -> UnixSocket path
 #endif
 

--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -27,7 +27,7 @@ module Network.BSD
     , getHostByAddr
     , hostAddress
 
-#if defined(HAVE_GETHOSTENT) && !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
     , getHostEntries
 
     -- ** Low level functionality
@@ -43,7 +43,7 @@ module Network.BSD
     , getServiceByPort
     , getServicePortNumber
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
     , getServiceEntries
 
     -- ** Low level functionality
@@ -61,7 +61,7 @@ module Network.BSD
     , getProtocolNumber
     , defaultProtocol
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
     , getProtocolEntries
     -- ** Low level functionality
     , setProtocolEntry
@@ -77,7 +77,7 @@ module Network.BSD
     , NetworkAddr
     , NetworkEntry(..)
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
     , getNetworkByName
     , getNetworkByAddr
     , getNetworkEntries
@@ -99,7 +99,7 @@ import Network.Socket
 import Control.Concurrent (MVar, newMVar, withMVar)
 import qualified Control.Exception as E
 import Foreign.C.String (CString, peekCString, withCString)
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
 import Foreign.C.Types ( CShort )
 #endif
 import Foreign.C.Types ( CInt(..), CUInt(..), CULong(..), CSize(..) )
@@ -158,7 +158,7 @@ instance Storable ServiceEntry where
         return (ServiceEntry {
                         serviceName     = s_name,
                         serviceAliases  = s_aliases,
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
                         servicePort     = (fromIntegral (s_port :: CShort)),
 #else
                            -- s_port is already in network byte order, but it
@@ -202,7 +202,7 @@ getServicePortNumber name = do
     (ServiceEntry _ _ port _) <- getServiceByName name "tcp"
     return port
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 getServiceEntry :: IO ServiceEntry
 getServiceEntry = withLock $ do
  throwNoSuchThingIfNull "getServiceEntry" "no such service entry"
@@ -255,7 +255,7 @@ instance Storable ProtocolEntry where
         p_aliases <- (#peek struct protoent, p_aliases) p
                            >>= peekArray0 nullPtr
                            >>= mapM peekCString
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
          -- With WinSock, the protocol number is only a short;
          -- hoist it in as such, but represent it on the Haskell side
          -- as a CInt.
@@ -298,7 +298,7 @@ getProtocolNumber proto = do
  (ProtocolEntry _ _ num) <- getProtocolByName proto
  return num
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
 getProtocolEntry = withLock $ do
  ent <- throwNoSuchThingIfNull "getProtocolEntry" "no such protocol entry"
@@ -351,7 +351,7 @@ instance Storable HostEntry where
         return (HostEntry {
                         hostName       = h_name,
                         hostAliases    = h_aliases,
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
                         hostFamily     = unpackFamily (fromIntegral (h_addrtype :: CShort)),
 #else
                         hostFamily     = unpackFamily h_addrtype,
@@ -397,7 +397,7 @@ getHostByAddr family addr = do
 foreign import CALLCONV safe "gethostbyaddr"
    c_gethostbyaddr :: Ptr HostAddress -> CInt -> CInt -> IO (Ptr HostEntry)
 
-#if defined(HAVE_GETHOSTENT) && !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
 getHostEntry :: IO HostEntry
 getHostEntry = withLock $ do
  throwNoSuchThingIfNull         "getHostEntry" "unable to retrieve host entry"
@@ -463,7 +463,7 @@ instance Storable NetworkEntry where
    poke _p = error "Storable.poke(BSD.NetEntry) not implemented"
 
 
-#if !defined(cygwin32_HOST_OS) && !defined(mingw32_HOST_OS) && !defined(_WIN32)
+#if !defined(mingw32_HOST_OS)
 getNetworkByName :: NetworkName -> IO NetworkEntry
 getNetworkByName name = withLock $ do
  withCString name $ \ name_cstr -> do

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -424,7 +424,7 @@ connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = withSocke
            r <- c_connect s p_addr (fromIntegral sz)
            if r == -1
                then do
-#if !(defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS))
+#if !(defined(HAVE_WINSOCK2_H))
                    err <- getErrno
                    case () of
                      _ | err == eINTR       -> connectLoop

--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -43,7 +43,7 @@ module Network.Socket.Internal
     , Family(..)
 
     -- * Socket error functions
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
     , c_getLastError
 #endif
     , throwSocketError
@@ -77,7 +77,7 @@ import Foreign.C.Types (CInt(..))
 import Foreign.Ptr (Ptr)
 import GHC.Conc (threadWaitRead, threadWaitWrite)
 
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
 import Control.Exception ( evaluate )
 import System.IO.Unsafe ( unsafePerformIO )
 import Control.Monad ( when )
@@ -154,7 +154,7 @@ throwSocketErrorIfMinus1RetryMayBlock
 {-# SPECIALIZE throwSocketErrorIfMinus1RetryMayBlock
         :: String -> IO b -> IO CInt -> IO CInt #-}
 
-#if (!defined(HAVE_WINSOCK2_H) || defined(cygwin32_HOST_OS))
+#if (!defined(HAVE_WINSOCK2_H))
 
 throwSocketErrorIfMinus1RetryMayBlock name on_block act =
     throwErrnoIfMinus1RetryMayBlock name act on_block
@@ -177,7 +177,7 @@ throwSocketErrorIfMinus1_ name act = do
   throwSocketErrorIfMinus1Retry name act
   return ()
 
-# if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+# if defined(HAVE_WINSOCK2_H)
 throwSocketErrorIfMinus1Retry name act = do
   r <- act
   if (r == -1)

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -847,7 +847,7 @@ isSupportedSockAddr addr = case addr of
   _ -> False
 #endif
 
-#if defined(WITH_WINSOCK) || defined(cygwin32_HOST_OS)
+#if defined(WITH_WINSOCK)
 type CSaFamily = (#type unsigned short)
 #elif defined(darwin_HOST_OS)
 type CSaFamily = (#type u_char)

--- a/cbits/asyncAccept.c
+++ b/cbits/asyncAccept.c
@@ -5,7 +5,7 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
+#if defined(HAVE_WINSOCK2_H)
 
 /* all the way to the end */
 

--- a/cbits/initWinSock.c
+++ b/cbits/initWinSock.c
@@ -1,7 +1,7 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
+#if defined(HAVE_WINSOCK2_H)
 
 static int winsock_inited = 0;
 

--- a/cbits/winSockErr.c
+++ b/cbits/winSockErr.c
@@ -1,7 +1,7 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
+#if defined(HAVE_WINSOCK2_H)
 #include <stdio.h>
 
 /* to the end */

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -36,7 +36,7 @@
 # undef IPV6_SOCKET_SUPPORT
 #endif
 
-#if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
+#if defined(HAVE_WINSOCK2_H)
 #include <winsock2.h>
 # ifdef HAVE_WS2TCPIP_H
 #  include <ws2tcpip.h>
@@ -115,7 +115,7 @@ sendFd(int sock, int outfd);
 extern int
 recvFd(int sock);
 
-#endif /* HAVE_WINSOCK2_H && !__CYGWIN */
+#endif /* HAVE_WINSOCK2_H */
 
 INLINE char *
 my_inet_ntoa(
@@ -138,7 +138,7 @@ my_inet_ntoa(
 #ifdef HAVE_GETADDRINFO
 INLINE int
 hsnet_getnameinfo(const struct sockaddr* a,socklen_t b, char* c,
-# if defined(HAVE_WINSOCK2_H) && !defined(__CYGWIN__)
+# if defined(HAVE_WINSOCK2_H)
                   DWORD d, char* e, DWORD f, int g)
 # else
                   socklen_t d, char* e, socklen_t f, int g)
@@ -161,7 +161,7 @@ hsnet_freeaddrinfo(struct addrinfo *ai)
 }
 #endif
 
-#if defined(HAVE_WINSOCK2_H) && !defined(cygwin32_HOST_OS)
+#if defined(HAVE_WINSOCK2_H)
 # define WITH_WINSOCK  1
 #endif
 


### PR DESCRIPTION
As noted recently on the mailing lists in the context of the containers
package, there's not much point in retaining support for versions we
cannot test. Cygwin has been unsupported by GHC for some time now. CI
currently tests network all the way back to GHC 7.0.4. But even in that
version, `cygwin32_HOST_OS` is never set. So effectively any occurrence
of `|| defined(cygwin32_HOST_OS)` or `&& !defined(cygwin32_HOST_OS)` is
equivalent to `|| FALSE` and `&& TRUE`, respectively. On all platforms
on all tested versions of GHC.

This patch removes these occurrences, thus simplifying, making
consistent, less error prone, and more readable the conditionals testing
for whether the current platform is Windows.