### PR TITLE
CI on 64-bit Windows via Appveyor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ include/HsNetworkConfig.h.in
 network.buildinfo
 cabal.sandbox.config
 .cabal-sandbox
+.stack-work/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+cache:
+- c:\sr -> stack.yaml # stack root, short paths == fewer problems
+- C:\Users\appveyor\AppData\Local\Programs\stack\x86_64-windows -> stack.yaml
+
+clone_folder: "c:\\network"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+install:
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
+- 7z x stack.zip stack.exe
+- stack --no-terminal setup > nul
+- C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
+
+build_script:
+- stack --no-terminal build
+
+test_script:
+# Run all test suites except doctests, because that one assumes
+# cabal-install. TODO reenable it:
+# https://github.com/haskell/network/issues/196.
+- stack --no-terminal test network:test:simple network:test:regression
+
+deploy: off


### PR DESCRIPTION
Uses Stack as the build and test driver, for convenience. Stack takes
care of installing the right version of GHC and other build tools for
us. Which is rather convenient on Windows given the general lack of
standard package manager.

32-bit to be enabled in a separate PR: strange linker errors at the
moment.

Sample output can be found here:
https://ci.appveyor.com/project/mboes/network/build/1.0.18. Someone with
admin rights on the official network repo will have to enable Appveyor
as a service for this PR to be useful.