### PR TITLE
Added nightly to appveyor matrix and upgraded to 6.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,6 @@ test_script:
 # Run all test suites except doctests, because that one assumes
 # cabal-install. TODO reenable it:
 # https://github.com/haskell/network/issues/196.
-  - stack --no-terminal test --resolver %stack_lts% --reconfigure network:test:simple network:test:regression
+- stack --no-terminal test --resolver %stack_lts% --reconfigure network:test:simple network:test:regression
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
 
 build_script:
-- stack --no-terminal build --resolver %stack_lts%
+- stack --no-terminal build --resolver %stack_lts% --reconfigure
 
 test_script:
 # Run all test suites except doctests, because that one assumes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ matrix:
 install:
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
-- stack --no-terminal setup --resolver $env:stack_lts > nul
+- stack --no-terminal setup --resolver "$env:stack_lts" > nul
 - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
 
 build_script:
@@ -27,6 +27,6 @@ test_script:
 # Run all test suites except doctests, because that one assumes
 # cabal-install. TODO reenable it:
 # https://github.com/haskell/network/issues/196.
-  - stack --no-terminal test --resolver $env:stack_lts --reconfigure network:test:simple network:test:regression
+  - stack --no-terminal test --resolver "$env:stack_lts" --reconfigure network:test:simple network:test:regression
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,18 @@ clone_folder: "c:\\network"
 environment:
   global:
     STACK_ROOT: "c:\\sr"
+  matrix:
+    - stack_lts: lts-6.2
+    - stack_lts: nightly
+
+matrix:
+  allow_failures:
+    - stack_lts: nightly
 
 install:
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
-- stack --no-terminal setup > nul
+- stack --no-terminal setup --resolver $env:stack_lts > nul
 - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
 
 build_script:
@@ -20,6 +27,6 @@ test_script:
 # Run all test suites except doctests, because that one assumes
 # cabal-install. TODO reenable it:
 # https://github.com/haskell/network/issues/196.
-- stack --no-terminal test network:test:simple network:test:regression
+  - stack --no-terminal test --resolver $env:stack_lts --reconfigure network:test:simple network:test:regression
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ matrix:
 install:
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
-- stack --no-terminal setup --resolver "$env:stack_lts" > nul
+- stack --no-terminal setup --resolver %stack_lts% > nul
 - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
 
 build_script:
@@ -27,6 +27,6 @@ test_script:
 # Run all test suites except doctests, because that one assumes
 # cabal-install. TODO reenable it:
 # https://github.com/haskell/network/issues/196.
-  - stack --no-terminal test --resolver "$env:stack_lts" --reconfigure network:test:simple network:test:regression
+  - stack --no-terminal test --resolver %stack_lts% --reconfigure network:test:simple network:test:regression
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ environment:
   global:
     STACK_ROOT: "c:\\sr"
   matrix:
-    - stack_lts: lts-6.2
-    - stack_lts: nightly
+    - stack_lts: "lts-6.2"
+    - stack_lts: "nightly"
 
 matrix:
   allow_failures:
-    - stack_lts: nightly
+    - stack_lts: "nightly"
 
 install:
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i"
 
 build_script:
-- stack --no-terminal build
+- stack --no-terminal build --resolver %stack_lts%
 
 test_script:
 # Run all test suites except doctests, because that one assumes

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.17
+resolver: lts-6.2
 packages:
 - '.'
 ghc-options:


### PR DESCRIPTION
We build cabal with nightly GHC, it would be good to run windows against nightly stackage with allowable failure. I've also upgraded to the latest stackage.