### PR TITLE
Add `ntohl` and export it together with `htonl`.

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -41,6 +41,8 @@ module Network.Socket
     , FlowInfo
     , ScopeID
 #endif
+    , htonl
+    , ntohl
     , ShutdownCmd(..)
     , ProtocolNumber
     , defaultProtocol
@@ -1021,7 +1023,10 @@ aNY_PORT = 0
 iNADDR_ANY :: HostAddress
 iNADDR_ANY = htonl (#const INADDR_ANY)
 
+-- | Converts the from host byte order to network byte order.
 foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
+-- | Converts the from network byte order to host byte order.
+foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
 
 #if defined(IPV6_SOCKET_SUPPORT)
 -- | The IPv6 wild card address.


### PR DESCRIPTION
`HostAddress6` uses host byte order, but there seem to be no convenient functions for such a conversion. Exporting the native functions seem to be the simplest way to do this.

See also [Host byte order and network's HostAddress6](http://stackoverflow.com/q/37845817/1333025).