### PR TITLE
network.cabal: add Regression.Issue215 to source tarball

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -96,6 +96,7 @@ test-suite simple
 test-suite regression
   hs-source-dirs: tests
   main-is: Regression.hs
+  other-modules: Regression.Issue215
   type: exitcode-stdio-1.0
 
   build-depends:


### PR DESCRIPTION
Noticed when tried to build test suite on latest release:
  [1 of 1] Compiling Main             ( tests/Regression.hs, dist/build/regression/regression-tmp/Main.dyn_o )

  tests/Regression.hs:12:1: error:
    Failed to load interface for ‘Regression.Issue215’
    Use -v to see a list of the files searched for.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>