### PR TITLE
Rename my_inet_ntoa

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1542,7 +1542,7 @@ mkEOFError loc = ioeSetErrorString (mkIOError EOF loc Nothing Nothing) "end of f
 -- ---------------------------------------------------------------------------
 -- foreign imports from the C library
 
-foreign import ccall unsafe "my_inet_ntoa"
+foreign import ccall unsafe "hsnet_inet_ntoa"
   c_inet_ntoa :: HostAddress -> IO (Ptr CChar)
 
 foreign import CALLCONV unsafe "inet_addr"

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -118,7 +118,7 @@ recvFd(int sock);
 #endif /* HAVE_WINSOCK2_H */
 
 INLINE char *
-my_inet_ntoa(
+hsnet_inet_ntoa(
 #if defined(HAVE_WINSOCK2_H)
              u_long addr
 #elif defined(HAVE_IN_ADDR_T)
@@ -129,7 +129,7 @@ my_inet_ntoa(
              unsigned long addr
 #endif
 	    )
-{ 
+{
     struct in_addr a;
     a.s_addr = addr;
     return inet_ntoa(a);


### PR DESCRIPTION
This symbol conflicts with `my_inet_ntoa` from `mysql` and since
it's internal to the library, we can rename it.