### PR TITLE
Improve error messages

### DIFF
--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -168,7 +168,7 @@ instance Storable ServiceEntry where
                         serviceProtocol = s_proto
                 })
 
-   poke _p = error "Storable.poke(BSD.ServiceEntry) not implemented"
+   poke = throwUnsupportedOperationPoke "ServiceEntry"
 
 
 -- | Get service by name.
@@ -178,7 +178,7 @@ getServiceByName :: ServiceName         -- Service Name
 getServiceByName name proto = withLock $ do
  withCString name  $ \ cstr_name  -> do
  withCString proto $ \ cstr_proto -> do
- throwNoSuchThingIfNull "getServiceByName" "no such service entry"
+ throwNoSuchThingIfNull "Network.BSD.getServiceByName" "no such service entry"
    $ c_getservbyname cstr_name cstr_proto
  >>= peek
 
@@ -189,7 +189,7 @@ foreign import CALLCONV unsafe "getservbyname"
 getServiceByPort :: PortNumber -> ProtocolName -> IO ServiceEntry
 getServiceByPort port proto = withLock $ do
  withCString proto $ \ cstr_proto -> do
- throwNoSuchThingIfNull "getServiceByPort" "no such service entry"
+ throwNoSuchThingIfNull "Network.BSD.getServiceByPort" "no such service entry"
    $ c_getservbyport (fromIntegral port) cstr_proto
  >>= peek
 
@@ -205,7 +205,7 @@ getServicePortNumber name = do
 #if !defined(mingw32_HOST_OS)
 getServiceEntry :: IO ServiceEntry
 getServiceEntry = withLock $ do
- throwNoSuchThingIfNull "getServiceEntry" "no such service entry"
+ throwNoSuchThingIfNull "Network.BSD.getServiceEntry" "no such service entry"
    $ c_getservent
  >>= peek
 
@@ -270,12 +270,13 @@ instance Storable ProtocolEntry where
                         protoNumber  = p_proto
                 })
 
-   poke _p = error "Storable.poke(BSD.ProtocolEntry) not implemented"
+   poke = throwUnsupportedOperationPoke "ProtocolEntry"
+
 
 getProtocolByName :: ProtocolName -> IO ProtocolEntry
 getProtocolByName name = withLock $ do
  withCString name $ \ name_cstr -> do
- throwNoSuchThingIfNull "getProtocolByName" ("no such protocol name: " ++ name)
+ throwNoSuchThingIfNull "Network.BSD.getProtocolByName" ("no such protocol name: " ++ name)
    $ c_getprotobyname name_cstr
  >>= peek
 
@@ -285,7 +286,7 @@ foreign import  CALLCONV unsafe  "getprotobyname"
 
 getProtocolByNumber :: ProtocolNumber -> IO ProtocolEntry
 getProtocolByNumber num = withLock $ do
- throwNoSuchThingIfNull "getProtocolByNumber" ("no such protocol number: " ++ show num)
+ throwNoSuchThingIfNull "Network.BSD.getProtocolByNumber" ("no such protocol number: " ++ show num)
    $ c_getprotobynumber (fromIntegral num)
  >>= peek
 
@@ -301,7 +302,7 @@ getProtocolNumber proto = do
 #if !defined(mingw32_HOST_OS)
 getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
 getProtocolEntry = withLock $ do
- ent <- throwNoSuchThingIfNull "getProtocolEntry" "no such protocol entry"
+ ent <- throwNoSuchThingIfNull "Network.BSD.getProtocolEntry" "no such protocol entry"
                 $ c_getprotoent
  peek ent
 
@@ -359,14 +360,14 @@ instance Storable HostEntry where
                         hostAddresses  = h_addr_list
                 })
 
-   poke _p = error "Storable.poke(BSD.ServiceEntry) not implemented"
+   poke = throwUnsupportedOperationPoke "HostEntry"
 
 
 -- convenience function:
 hostAddress :: HostEntry -> HostAddress
 hostAddress (HostEntry nm _ _ ls) =
  case ls of
-   []    -> error ("BSD.hostAddress: empty network address list for " ++ nm)
+   []    -> error $ "Network.BSD.hostAddress: empty network address list for " ++ nm
    (x:_) -> x
 
 -- getHostByName must use the same lock as the *hostent functions
@@ -376,7 +377,7 @@ hostAddress (HostEntry nm _ _ ls) =
 getHostByName :: HostName -> IO HostEntry
 getHostByName name = withLock $ do
   withCString name $ \ name_cstr -> do
-   ent <- throwNoSuchThingIfNull "getHostByName" "no such host entry"
+   ent <- throwNoSuchThingIfNull "Network.BSD.getHostByName" "no such host entry"
                 $ c_gethostbyname name_cstr
    peek ent
 
@@ -390,7 +391,7 @@ foreign import CALLCONV safe "gethostbyname"
 getHostByAddr :: Family -> HostAddress -> IO HostEntry
 getHostByAddr family addr = do
  with addr $ \ ptr_addr -> withLock $ do
- throwNoSuchThingIfNull         "getHostByAddr" "no such host entry"
+ throwNoSuchThingIfNull "Network.BSD.getHostByAddr" "no such host entry"
    $ c_gethostbyaddr ptr_addr (fromIntegral (sizeOf addr)) (packFamily family)
  >>= peek
 
@@ -400,7 +401,7 @@ foreign import CALLCONV safe "gethostbyaddr"
 #if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
 getHostEntry :: IO HostEntry
 getHostEntry = withLock $ do
- throwNoSuchThingIfNull         "getHostEntry" "unable to retrieve host entry"
+ throwNoSuchThingIfNull "Network.BSD.getHostEntry" "unable to retrieve host entry"
    $ c_gethostent
  >>= peek
 
@@ -460,14 +461,14 @@ instance Storable NetworkEntry where
                         networkAddress   = n_net
                 })
 
-   poke _p = error "Storable.poke(BSD.NetEntry) not implemented"
+   poke = throwUnsupportedOperationPoke "NetworkEntry"
 
 
 #if !defined(mingw32_HOST_OS)
 getNetworkByName :: NetworkName -> IO NetworkEntry
 getNetworkByName name = withLock $ do
  withCString name $ \ name_cstr -> do
-  throwNoSuchThingIfNull "getNetworkByName" "no such network entry"
+  throwNoSuchThingIfNull "Network.BSD.getNetworkByName" "no such network entry"
     $ c_getnetbyname name_cstr
   >>= peek
 
@@ -476,7 +477,7 @@ foreign import ccall unsafe "getnetbyname"
 
 getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
 getNetworkByAddr addr family = withLock $ do
- throwNoSuchThingIfNull "getNetworkByAddr" "no such network entry"
+ throwNoSuchThingIfNull "Network.BSD.getNetworkByAddr" "no such network entry"
    $ c_getnetbyaddr addr (packFamily family)
  >>= peek
 
@@ -485,7 +486,7 @@ foreign import ccall unsafe "getnetbyaddr"
 
 getNetworkEntry :: IO NetworkEntry
 getNetworkEntry = withLock $ do
- throwNoSuchThingIfNull "getNetworkEntry" "no more network entries"
+ throwNoSuchThingIfNull "Network.BSD.getNetworkEntry" "no more network entries"
           $ c_getnetent
  >>= peek
 
@@ -549,7 +550,7 @@ getHostName :: IO HostName
 getHostName = do
   let size = 256
   allocaArray0 size $ \ cstr -> do
-    throwSocketErrorIfMinus1_ "getHostName" $ c_gethostname cstr (fromIntegral size)
+    throwSocketErrorIfMinus1_ "Network.BSD.getHostName" $ c_gethostname cstr (fromIntegral size)
     peekCString cstr
 
 foreign import CALLCONV unsafe "gethostname"
@@ -577,3 +578,12 @@ throwNoSuchThingIfNull loc desc act = do
   if (ptr == nullPtr)
    then ioError (ioeSetErrorString (mkIOError NoSuchThing loc Nothing Nothing) desc)
    else return ptr
+
+throwUnsupportedOperationPoke :: String -> Ptr a -> a -> IO ()
+throwUnsupportedOperationPoke typ _ _ =
+  ioError $ ioeSetErrorString ioe "Operation not implemented"
+  where
+    ioe = mkIOError UnsupportedOperation
+                    ("Network.BSD: instance Storable " ++ typ ++ ": poke")
+                    Nothing
+                    Nothing

--- a/Network/Socket/ByteString.hsc
+++ b/Network/Socket/ByteString.hsc
@@ -167,7 +167,7 @@ sendMany sock@(MkSocket fd _ _ _ _) cs = do
   where
     sendManyInner =
       liftM fromIntegral . withIOVec cs $ \(iovsPtr, iovsLen) ->
-          throwSocketErrorWaitWrite sock "writev" $
+          throwSocketErrorWaitWrite sock "Network.Socket.ByteString.sendMany" $
               c_writev (fromIntegral fd) iovsPtr
               (fromIntegral (min iovsLen (#const IOV_MAX)))
 #else
@@ -198,7 +198,7 @@ sendManyTo sock@(MkSocket fd _ _ _ _) cs addr = do
                 addrPtr (fromIntegral addrSize)
                 iovsPtr (fromIntegral iovsLen)
           with msgHdr $ \msgHdrPtr ->
-            throwSocketErrorWaitWrite sock "sendmsg" $
+            throwSocketErrorWaitWrite sock "Network.Socket.ByteString.sendManyTo" $
               c_sendmsg (fromIntegral fd) msgHdrPtr 0
 #else
 sendManyTo sock cs = sendAllTo sock (B.concat cs)

--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -266,7 +266,8 @@ withSocketsInit :: ()
 -- Use a CAF to make forcing it do initialisation once, but subsequent forces will be cheap
 withSocketsInit = unsafePerformIO $ do
     x <- initWinSock
-    when (x /= 0) $ ioError $ userError "Failed to initialise WinSock"
+    when (x /= 0) $ ioError $
+      userError "Network.Socket.Internal.withSocketsDo: Failed to initialise WinSock"
 
 foreign import ccall unsafe "initWinSock" initWinSock :: IO Int
 

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -59,7 +59,6 @@ module Network.Socket.Types
     ) where
 
 import Control.Concurrent.MVar
-import Control.Exception (throwIO)
 import Control.Monad
 import Data.Bits
 import Data.Maybe
@@ -724,8 +723,9 @@ unpackFamily f = case f of
 #ifdef AF_CAN
         (#const AF_CAN) -> AF_CAN
 #endif
-        unknown -> error ("Network.Socket.unpackFamily: unknown address " ++
-                          "family " ++ show unknown)
+        unknown -> error $
+          "Network.Socket.Types.unpackFamily: unknown address family: " ++
+          show unknown
 
 ------------------------------------------------------------------------
 -- Port Numbers
@@ -892,8 +892,9 @@ sizeOfSockAddrByFamily AF_INET  = #const sizeof(struct sockaddr_in)
 #if defined(CAN_SOCKET_SUPPORT)
 sizeOfSockAddrByFamily AF_CAN   = #const sizeof(struct sockaddr_can)
 #endif
-sizeOfSockAddrByFamily family =
-    error $ "sizeOfSockAddrByFamily: " ++ show family ++ " not supported."
+sizeOfSockAddrByFamily family = error $
+    "Network.Socket.Types.sizeOfSockAddrByFamily: address family '" ++
+    show family ++ "' not supported."
 
 -- | Use a 'SockAddr' with a function requiring a pointer to a
 -- 'SockAddr' and the length of that 'SockAddr'.
@@ -994,7 +995,9 @@ peekSockAddr p = do
         ifidx <- (#peek struct sockaddr_can, can_ifindex) p
         return (SockAddrCan ifidx)
 #endif
-    _ -> throwIO $ userError $ "peekSockAddr: " ++ show family ++ " not supported on this platform."
+    _ -> ioError $ userError $
+      "Network.Socket.Types.peekSockAddr: address family '" ++
+      show family ++ "' not supported."
 
 ------------------------------------------------------------------------
 

--- a/tests/Simple.hs
+++ b/tests/Simple.hs
@@ -344,7 +344,7 @@ getPeerPort sock = do
     case sockAddr of
         (SockAddrInet port _) -> return port
         (SockAddrInet6 port _ _ _) -> return port
-        _ -> error "getPeerPort: only works with IP sockets"
+        _ -> ioError $ userError "getPeerPort: only works with IP sockets"
 
 -- | Establish a connection between client and server and then run
 -- 'clientAct' and 'serverAct', in different threads.  Both actions


### PR DESCRIPTION
I ran into the following error in an application:

```
*** Exception: connect: does not exist (No such file or directory)
```

It took more time than it should have to (1) trace the error to `Network.connectTo` which calls `Network.Socket.connect` and (2) determine that the failure was due to a default use of a Unix socket file that did not exist.

After looking at the error messages in `network`, I realized that almost none of them included the module name in the location. So, I did a bit of an audit of the error messages. The following error is part of the result, and I find it to be more helpful:

```
*Network> _ <- connectTo "localhost" (UnixSocket "file-does-not-exist")
*** Exception: Network.Socket.connect: <socket: 11>: does not exist (No such file or directory)
```

These are the highlights:

* Add module name where missing
* Use `ioError` instead of `error` and `throwIO` consistently