### PR TITLE
Make setNonBlockIfNeeded public and document its use.

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -81,7 +81,8 @@ import Foreign.Storable
 --   * Status flag
 --
 --   If you are calling the 'MkSocket' constructor directly you should ensure
---   you have called 'Network.withSocketsDo'.
+--   you have called 'Network.withSocketsDo' and that the file descriptor is
+--   in non-blocking mode. See 'Network.Socket.setNonBlockIfNeeded'.
 data Socket
   = MkSocket
             CInt                 -- File Descriptor


### PR DESCRIPTION
Making a socket out of a file descriptor may cause the RTS to hang when the fd blocks, so we need to use `setNonBlockIfNeeded` when using file descriptors that were not created by the `network` library (which is an otherwise supported use case)
This PR contains the export and the extra documentation.

Note that it is possible to make `network` more robust against this situation by adding the call to `mkSocket`, but that will introduce unnecessary system calls in almost all situations. Haskell has been doing pretty well without that extra safety. (famous last words)