### PR TITLE
Remove old GHC version from travis and document policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.0.4
-      compiler: ": #GHC 7.0.4"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.4.2
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.3
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
@@ -41,8 +32,6 @@ matrix:
       compiler: ": #GHC head"
       addons: {apt: {packages: [cabal-install-1.24,ghc-head], sources: [hvr-ghc]}}
   allow_failures:
-    - env: CABALVER=1.16 GHCVER=7.0.4
-    - env: CABALVER=1.16 GHCVER=7.4.2
     - env: CABALVER=1.24 GHCVER=head
 
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ do this for you.
 
 ### GHC
 
-Our GHC policy supports 3 [stable](https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/intro.html#ghc-version-numbering-policy) versions. The current stable
+`network`'s GHC policy supports 3 [stable](https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/intro.html#ghc-version-numbering-policy) versions. The current stable
 version and two previous stable versions are supported.
 
 ### Hugs, JHC, UHC
 
-We do not officially support these compilers.
+`network` does not officially support these compilers.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # [`network`](http://hackage.haskell.org/package/network) [![Build Status](https://travis-ci.org/haskell/network.svg?branch=master)](https://travis-ci.org/haskell/network) [![Build status](https://ci.appveyor.com/api/projects/status/5erq63o4m29bhl57/branch/master?svg=true)](https://ci.appveyor.com/project/eborden/network/branch/master)
 
-
-
 To build this package using Cabal directly from git, you must run
 `autoreconf` before the usual Cabal build steps
 (configure/build/install).  `autoreconf` is included in the
 [GNU Autoconf](http://www.gnu.org/software/autoconf/) tools.  There is
 no need to run the `configure` script: the `setup configure` step will
 do this for you.
+
+## Support Policy
+
+### GHC
+
+Our GHC policy supports 3 [stable](https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/intro.html#ghc-version-numbering-policy) versions. The current stable
+version and two previous stable versions are supported.
+
+### Hugs, JHC, UHC
+
+We do not officially support these compilers.

--- a/network.cabal
+++ b/network.cabal
@@ -41,7 +41,7 @@ extra-source-files:
   cbits/winSockErr.c
 homepage:       https://github.com/haskell/network
 bug-reports:    https://github.com/haskell/network/issues
-tested-with:   GHC == 7.0.4, GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1
+tested-with:   GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.0.2
 
 library
   exposed-modules:


### PR DESCRIPTION
Currently were supporting 7.6.* to 8.0.* via our travis rules. This
made our defacto support a 4 stable version policy. This is a wider
than necessary. We are switching to a 3 stable version policy to
simplify support and reduce build times.

This addresses #248 