### PR TITLE
v2.6.3.2 Release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,28 @@
 ## Version 2.6.3.2
 
- * Zero memory of sockaddr_un if abstract socket
+ * Zero memory of `sockaddr_un` if abstract socket
    [#220](https://github.com/haskell/network/pull/220)
+
+ * Improving error messages
+   [#232](https://github.com/haskell/network/pull/232)
+
+ * Allow non-blocking file descriptors via `setNonBlockIfNeeded`
+   [#242](https://github.com/haskell/network/pull/242)
+
+ * Update config.{guess,sub} to latest version
+   [#244](https://github.com/haskell/network/pull/244)
+
+ * Rename `my_inet_ntoa` to avoid symbol conflicts
+   [#228](https://github.com/haskell/network/pull/228)
+
+ * Test infrastructure improvements
+   [#219](https://github.com/haskell/network/pull/219)
+   [#217](https://github.com/haskell/network/pull/217)
+   [#218](https://github.com/haskell/network/pull/218)
+
+ * House keeping and cleanup
+   [#238](https://github.com/haskell/network/pull/238)
+   [#237](https://github.com/haskell/network/pull/237)
 
 ## Version 2.6.3.1
 

--- a/network.cabal
+++ b/network.cabal
@@ -1,5 +1,5 @@
 name:           network
-version:        2.6.3.1
+version:        2.6.3.2
 license:        BSD3
 license-file:   LICENSE
 maintainer:     Kazu Yamamoto, Evan Borden
@@ -41,7 +41,7 @@ extra-source-files:
   cbits/winSockErr.c
 homepage:       https://github.com/haskell/network
 bug-reports:    https://github.com/haskell/network/issues
-tested-with:   GHC == 7.0.4, GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1
+tested-with:   GHC == 7.0.4, GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.0.2
 
 library
   exposed-modules:


### PR DESCRIPTION
 * Zero memory of `sockaddr_un` if abstract socket
   [#220](https://github.com/haskell/network/pull/220)

 * Improving error messages
   [#232](https://github.com/haskell/network/pull/232)

 * Allow non-blocking file descriptors via `setNonBlockIfNeeded`
   [#242](https://github.com/haskell/network/pull/242)

 * Update config.{guess,sub} to latest version
   [#244](https://github.com/haskell/network/pull/244)

 * Rename `my_inet_ntoa` to avoid symbol conflicts
   [#228](https://github.com/haskell/network/pull/228)

 * Test infrastructure improvements
   [#219](https://github.com/haskell/network/pull/219)
   [#217](https://github.com/haskell/network/pull/217)
   [#218](https://github.com/haskell/network/pull/218)

 * House keeping and cleanup
   [#238](https://github.com/haskell/network/pull/238)
   [#237](https://github.com/haskell/network/pull/237)