### PR TITLE
comparing a return value of c_inet_addr with a positive number.

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1181,7 +1181,7 @@ inet_addr :: String -> IO HostAddress
 inet_addr ipstr = withSocketsDo $ do
    withCString ipstr $ \str -> do
    had <- c_inet_addr str
-   if had == -1
+   if had == maxBound
     then ioError $ userError $
       "Network.Socket.inet_addr: Malformed address: " ++ ipstr
     else return had  -- network byte order


### PR DESCRIPTION
`c_inet_addr` returns a value of `Word32`.
So, we cannot compare it with (-1).
GHC 8.2 detects this bug.