### PR TITLE
Update stackage lts for windows builds.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.2
+resolver: lts-9.18
 packages:
 - '.'
 ghc-options:


### PR DESCRIPTION
The LTS for our appveyor builds is wildly out of date. 