### PR TITLE
Officially deprecate the Network module

### DIFF
--- a/Network.hs
+++ b/Network.hs
@@ -24,7 +24,7 @@
 #define IPV6_SOCKET_SUPPORT 1
 #endif
 
-module Network
+module Network {-# DEPRECATED "The high level Network interface is no longer supported. Please use Network.Socket." #-}
     (
     -- * Basic data types
       Socket

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -15,9 +15,6 @@
 -- this module; in general the operations follow the behaviour of the C
 -- functions of the same name (consult your favourite Unix networking book).
 --
--- A higher level interface to networking operations is provided
--- through the module "Network".
---
 -----------------------------------------------------------------------------
 
 #include "HsNet.h"


### PR DESCRIPTION
This module has been kept for backwards compatibility for a long time.
It has been unnoficially deprecated via documentation for a long time
(since 2014), but has never been given a proper deprecation flag. This
flag signals that using this module is an error and should be avoided,
something that can easily be missed by not reading the module summary.