### PR TITLE
GC sockets

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -342,7 +342,9 @@ mkSocket fd fam sType pNum stat = do
    mStat <- newMVar stat
    withSocketsDo $ return ()
    let sock = MkSocket fd fam sType pNum mStat
+##if MIN_VERSION_base(4,6,0)
    _ <- mkWeakMVar mStat $ close sock
+##endif
    return sock
 
 


### PR DESCRIPTION
When a `Socket` becomes unreachable but is not explicitly closed by `close`, GC should collect it.
This fixes #4 and #236.