### PR TITLE
Do not closeFd within sendFd

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1020,7 +1020,7 @@ closeFdWith closer fd = closer fd
 sendFd :: Socket -> CInt -> IO ()
 sendFd sock outfd = do
   _ <- throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $ c_sendFd (fdSocket sock) outfd
-  pure ()
+  return ()
 
 -- | Receive a file descriptor over a domain socket. Note that the resulting
 -- file descriptor may have to be put into non-blocking mode in order to be

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1018,12 +1018,8 @@ closeFdWith closer fd = closer fd
 -- sending/receiving ancillary socket data; low-level mechanism
 -- for transmitting file descriptors, mainly.
 sendFd :: Socket -> CInt -> IO ()
-sendFd sock outfd = do
-  _ <- ($) throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $
-     c_sendFd (fdSocket sock) outfd
-   -- Note: If Winsock supported FD-passing, thi would have been
-   -- incorrect (since socket FDs need to be closed via closesocket().)
-  closeFd outfd
+sendFd sock outfd =
+  void . throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $ c_sendFd (fdSocket sock) outfd
 
 -- | Receive a file descriptor over a domain socket. Note that the resulting
 -- file descriptor may have to be put into non-blocking mode in order to be

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1018,8 +1018,9 @@ closeFdWith closer fd = closer fd
 -- sending/receiving ancillary socket data; low-level mechanism
 -- for transmitting file descriptors, mainly.
 sendFd :: Socket -> CInt -> IO ()
-sendFd sock outfd =
-  void . throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $ c_sendFd (fdSocket sock) outfd
+sendFd sock outfd = do
+  _ <- throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $ c_sendFd (fdSocket sock) outfd
+  pure ()
 
 -- | Receive a file descriptor over a domain socket. Note that the resulting
 -- file descriptor may have to be put into non-blocking mode in order to be


### PR DESCRIPTION
It is common to close a file descriptor after sending it, however it is
not a required part of the work flow. There are uses for not closing a
file descriptor. Closing the file descriptor is too high level of a
decision.

Fix for #150 