### PR TITLE
Fix finalizer getting triggered in ghc 8.2.2

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -1226,8 +1226,8 @@ isWritable = isReadable -- sort of.
 
 isAcceptable :: Family -> SocketType -> SocketStatus -> Bool
 #if defined(DOMAIN_SOCKET_SUPPORT)
-isAcceptable AF_UNIX x status
-    | x == Stream || x == SeqPacket =
+isAcceptable AF_UNIX sockType status
+    | sockType == Stream || sockType == SeqPacket =
         status == Connected || status == Bound || status == Listening
 isAcceptable AF_UNIX _ _ = False
 #endif


### PR DESCRIPTION
GHC 8.2.2 more aggresively reclaims `Weak`. This causes the socket to be
closed in `accept` before `c_accept` is called. Utilizing `withMVar`
allows the reference to be held until `c_accept` has been called.

This fixes: #287 