### PR TITLE
Improve exception error messages for getAddrInfo and getNameInfo

### DIFF
--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -272,8 +272,17 @@ getAddrInfo hints node service = withSocketsDo $
                     c_freeaddrinfo ptr_addrs
                     return ais
             _ -> do err <- gai_strerror ret
+                    let message = concat
+                            [ "Network.Socket.getAddrInfo (called with preferred socket type/protocol: "
+                            , show hints
+                            , ", host name: "
+                            , show node
+                            , ", service name: "
+                            , show service
+                            , ")"
+                            ]
                     ioError (ioeSetErrorString
-                             (mkIOError NoSuchThing "Network.Socket.getAddrInfo" Nothing
+                             (mkIOError NoSuchThing message Nothing
                               Nothing) err)
     -- Leaving out the service and using AI_NUMERICSERV causes a
     -- segfault on OS X 10.8.2. This code removes AI_NUMERICSERV
@@ -354,8 +363,19 @@ getNameInfo flags doHost doService addr = withSocketsDo $
             serv <- peekIf doService c_serv
             return (host, serv)
           _ -> do err <- gai_strerror ret
+                  let message = concat
+                        [ "Network.Socket.getNameInfo (called with flags: "
+                        , show flags
+                        , ", hostname lookup: "
+                        , show doHost
+                        , ", service name lookup: "
+                        , show doService
+                        , ", socket address: "
+                        , show addr
+                        , ")"
+                        ]
                   ioError (ioeSetErrorString
-                           (mkIOError NoSuchThing "Network.Socket.getNameInfo" Nothing
+                           (mkIOError NoSuchThing message Nothing
                             Nothing) err)
 
 foreign import ccall safe "hsnet_getnameinfo"


### PR DESCRIPTION
@develop7 ran into an issue with `yesod devel` (https://github.com/yesodweb/yesod/issues/1471) and got the following error message:

```
devel.hs: Network.Socket.getAddrInfo: does not exist (Name or service not known)
```

It would be useful to have a more detailed error message to aid in debugging this exception. The new message looks like this:

```
> getAddrInfo Nothing (Just "127.0.0.1") (Just "foo")
*** Exception: Network.Socket.getAddrInfo (called with preferred socket type/protocol: Nothing, host name: Just "127.0.0.1", service name: Just "foo"): does not exist (nodename nor servname provided, or not known)
```

I think a more verbose error message is well worth it, especially since these kind of lower-level, underlying issues can be hard to debug.

(I added a similar error message for `getNameInfo` since it was right there)