### PR TITLE
Fix reading SockAddr during `accept` and add tests for Unix sockets

### DIFF
--- a/Network/Socket/Buffer.hs
+++ b/Network/Socket/Buffer.hs
@@ -104,7 +104,7 @@ recvBufFrom s ptr nbytes
         if len' == 0
             then ioError (mkEOFError "Network.Socket.recvFrom")
             else do
-                sockaddr <- peekSocketAddress ptr_sa
+                sockaddr <- peekSocketAddress ptr_sa ptr_len
                     `E.catch` \(E.SomeException _) -> getPeerName s
                 return (len', sockaddr)
 

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -115,7 +115,8 @@ instance Storable AddrInfo where
         ai_family <- (#peek struct addrinfo, ai_family) p
         ai_socktype <- (#peek struct addrinfo, ai_socktype) p
         ai_protocol <- (#peek struct addrinfo, ai_protocol) p
-        ai_addr <- (#peek struct addrinfo, ai_addr) p >>= peekSockAddr
+        ai_addr' <- (#peek struct addrinfo, ai_addr) p
+        ai_addr <- peekSockAddr ai_addr' undefined
         ai_canonname_ptr <- (#peek struct addrinfo, ai_canonname) p
 
         ai_canonname <- if ai_canonname_ptr == nullPtr

--- a/Network/Socket/Name.hs
+++ b/Network/Socket/Name.hs
@@ -6,6 +6,8 @@ module Network.Socket.Name (
     getPeerName
   , getSocketName
   , socketPort
+
+  , c_getsockname
   ) where
 
 import Foreign.Marshal.Utils (with)

--- a/Network/Socket/Name.hs
+++ b/Network/Socket/Name.hs
@@ -23,8 +23,7 @@ getPeerName s =
    with (fromIntegral sz) $ \int_star -> do
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getPeerName" $
        c_getpeername (fdSocket s) ptr int_star
-     _sz <- peek int_star
-     peekSocketAddress ptr
+     peekSocketAddress ptr int_star
 
 -- | Getting my socket address.
 getSocketName :: SocketAddress sa => Socket -> IO sa
@@ -33,7 +32,7 @@ getSocketName s =
    with (fromIntegral sz) $ \int_star -> do
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
        c_getsockname (fdSocket s) ptr int_star
-     peekSocketAddress ptr
+     peekSocketAddress ptr int_star
 
 foreign import CALLCONV unsafe "getpeername"
   c_getpeername :: CInt -> Ptr sa -> Ptr CInt -> IO CInt

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -25,6 +25,7 @@ import Network.Socket.Fcntl
 
 import Network.Socket.Imports
 import Network.Socket.Internal
+import Network.Socket.Name
 import Network.Socket.Options
 import Network.Socket.Types
 
@@ -200,6 +201,11 @@ accept s = withNewSocketAddress $ \sa sz -> do
      setNonBlockIfNeeded new_fd
      setCloseOnExecIfNeeded new_fd
 # endif /* HAVE_ADVANCED_SOCKET_FLAGS */
+     -- Some distros don't fill `sockaddr` appropriately in the `accept` syscall
+     -- Make an explicit call to pull the correct name
+     poke ptr_len (fromIntegral sz)
+     throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
+       c_getsockname new_fd sa ptr_len
 #endif
      addr <- peekSocketAddress sa
      let new_s = mkSocket new_fd

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -207,7 +207,7 @@ accept s = withNewSocketAddress $ \sa sz -> do
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
        c_getsockname new_fd sa ptr_len
 #endif
-     addr <- peekSocketAddress sa
+     addr <- peekSocketAddress sa ptr_len
      let new_s = mkSocket new_fd
      return (new_s, addr)
 

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -922,7 +922,8 @@ peekSockAddr p = do
   case family :: CSaFamily of
 #if defined(DOMAIN_SOCKET_SUPPORT)
     (#const AF_UNIX) -> do
-        str <- peekCString ((#ptr struct sockaddr_un, sun_path) p)
+        -- Unix addresses cannot have encodings
+        str <- peekCAString ((#ptr struct sockaddr_un, sun_path) p)
         return (SockAddrUnix str)
 #endif
     (#const AF_INET) -> do

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -765,7 +765,7 @@ defaultPort = 0
 -- | The core typeclass to unify socket addresses.
 class SocketAddress sa where
     sizeOfSocketAddress :: sa -> Int
-    peekSocketAddress :: Ptr sa -> IO sa
+    peekSocketAddress :: Ptr sa -> Ptr CInt -> IO sa
     pokeSocketAddress  :: Ptr a -> sa -> IO ()
 
 withSocketAddress :: SocketAddress sa => sa -> (Ptr sa -> Int -> IO a) -> IO a
@@ -915,15 +915,21 @@ pokeSockAddr p (SockAddrInet6 (PortNum port) flow addr scope) = do
     (#poke struct sockaddr_in6, sin6_addr) p (In6Addr addr)
     (#poke struct sockaddr_in6, sin6_scope_id) p scope
 
--- | Read a 'SockAddr' from the given memory location.
-peekSockAddr :: Ptr SockAddr -> IO SockAddr
-peekSockAddr p = do
+-- | Read a 'SockAddr' from the given memory location and length identifier
+peekSockAddr :: Ptr SockAddr -> Ptr CInt -> IO SockAddr
+peekSockAddr p _len = do
   family <- (#peek struct sockaddr, sa_family) p
   case family :: CSaFamily of
 #if defined(DOMAIN_SOCKET_SUPPORT)
     (#const AF_UNIX) -> do
+        -- Follow UNIX spec for potential non-null-terminated `sun_path`
+        addrlen <- peek _len
+        let addr_ptr = (#ptr struct sockaddr_un, sun_path) p
+            str_len = addrlen - (#offset struct sockaddr_un, sun_path)
+        addr_len <- fromIntegral <$> strnlen addr_ptr str_len
+
         -- Unix addresses cannot have encodings
-        str <- peekCAString ((#ptr struct sockaddr_un, sun_path) p)
+        str <- peekCAStringLen (addr_ptr, addr_len)
         return (SockAddrUnix str)
 #endif
     (#const AF_INET) -> do
@@ -1049,6 +1055,7 @@ instance Storable In6Addr where
 -- Helper functions
 
 foreign import ccall unsafe "string.h" memset :: Ptr a -> CInt -> CSize -> IO ()
+foreign import ccall unsafe "string.h" strnlen :: Ptr CChar -> CInt -> IO CSize
 
 -- | Zero a structure.
 zeroMemory :: Ptr a -> CSize -> IO ()

--- a/network.cabal
+++ b/network.cabal
@@ -97,6 +97,7 @@ test-suite spec
   build-depends:
     base < 5,
     bytestring,
+    directory,
     HUnit,
     network,
     hspec

--- a/tests/SimpleSpec.hs
+++ b/tests/SimpleSpec.hs
@@ -13,6 +13,8 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
 import Network.Socket
 import Network.Socket.ByteString
+import System.Directory
+import System.IO.Error
 import System.Timeout (timeout)
 
 import Test.Hspec
@@ -147,6 +149,15 @@ spec = do
                 `shouldBe` (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334)
 #endif
 
+    describe "unix sockets" $ do
+        it "basic unix sockets end-to-end" $ do
+            when isUnixDomainSocketAvailable $ do
+                let client sock = send sock testMsg
+                    server (sock, addr) = do
+                      recv sock 1024 `shouldReturn` testMsg
+                      addr `shouldBe` (SockAddrUnix unixAddr)
+                unixTest client server
+
 ------------------------------------------------------------------------
 
 serverAddr :: String
@@ -155,8 +166,38 @@ serverAddr = "127.0.0.1"
 testMsg :: ByteString
 testMsg = "This is a test message."
 
+unixAddr :: String
+unixAddr = "/tmp/network-test"
+
 ------------------------------------------------------------------------
 -- Test helpers
+
+-- | Establish a connection between client and server and then run
+-- 'clientAct' and 'serverAct', in different threads.  Both actions
+-- get passed a connected 'Socket', used for communicating between
+-- client and server.  'unixTest' makes sure that the 'Socket' is
+-- closed after the actions have run.
+unixTest :: (Socket -> IO a) -> ((Socket, SockAddr) -> IO b) -> IO ()
+unixTest clientAct serverAct = do
+    test clientSetup clientAct serverSetup server
+  where
+    clientSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        connect sock (SockAddrUnix unixAddr)
+        return sock
+
+    serverSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        bind sock (SockAddrUnix unixAddr)
+        listen sock 1
+        return sock
+
+    server sock = E.bracket (accept sock) (killClientSock . fst) serverAct
+
+    killClientSock sock = do
+        shutdown sock ShutdownBoth
+        close sock
+        E.tryJust (guard . isDoesNotExistError) $ removeFile unixAddr
 
 -- | Establish a connection between client and server and then run
 -- 'clientAct' and 'serverAct', in different threads.  Both actions


### PR DESCRIPTION
In trying to use Unix domain sockets, we've come across inconsistent failures during `accept`. I tracked it down to the calls to peek the socket address filled by the `accept` syscall. Apparently some unix distros (centos and OSX at the very least) do not fulfill the man spec of setting a null-terminated string in the `sun_path` field for unix sockets.

This SO accurately described the behavior I saw: https://stackoverflow.com/questions/17090043/unix-domain-sockets-accept-not-setting-sun-path

The changes here make an explicit syscall to get the socket address and appropriately peek it back out.
I added a new end-to-end test for unix sockets into the test suite. One of the conditions tests for a correctly returned socket address. Without the associated changes, the test fails by getting gobbledygook for the socket address.
I've tested this on OSX as well as centos.

I would have preferred to use `getSocketName` from the `Name` module, but the overloaded SocketAddress can't be resolved since it's outside the class instance. Fixing that looked like a larger refactor than fixing this bug. I would prefer to defer refactorings to later diffs as the `network` repo appears to be under heavy development.