### PR TITLE
Peek sockaddr for unix domain sockets according to non-null-terminating semantics

### DIFF
--- a/Network/Socket/Buffer.hs
+++ b/Network/Socket/Buffer.hs
@@ -104,7 +104,7 @@ recvBufFrom s ptr nbytes
         if len' == 0
             then ioError (mkEOFError "Network.Socket.recvFrom")
             else do
-                sockaddr <- peekSocketAddress ptr_sa
+                sockaddr <- peekSocketAddress ptr_sa (Just ptr_len)
                     `E.catch` \(E.SomeException _) -> getPeerName s
                 return (len', sockaddr)
 

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -115,7 +115,8 @@ instance Storable AddrInfo where
         ai_family <- (#peek struct addrinfo, ai_family) p
         ai_socktype <- (#peek struct addrinfo, ai_socktype) p
         ai_protocol <- (#peek struct addrinfo, ai_protocol) p
-        ai_addr <- (#peek struct addrinfo, ai_addr) p >>= peekSockAddr
+        ai_addr' <- (#peek struct addrinfo, ai_addr) p
+        ai_addr <-  peekSockAddr ai_addr' Nothing
         ai_canonname_ptr <- (#peek struct addrinfo, ai_canonname) p
 
         ai_canonname <- if ai_canonname_ptr == nullPtr

--- a/Network/Socket/Name.hs
+++ b/Network/Socket/Name.hs
@@ -21,8 +21,7 @@ getPeerName s =
    with (fromIntegral sz) $ \int_star -> do
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getPeerName" $
        c_getpeername (fdSocket s) ptr int_star
-     _sz <- peek int_star
-     peekSocketAddress ptr
+     peekSocketAddress ptr (Just int_star)
 
 -- | Getting my socket address.
 getSocketName :: SocketAddress sa => Socket -> IO sa
@@ -31,7 +30,7 @@ getSocketName s =
    with (fromIntegral sz) $ \int_star -> do
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
        c_getsockname (fdSocket s) ptr int_star
-     peekSocketAddress ptr
+     peekSocketAddress ptr (Just int_star)
 
 foreign import CALLCONV unsafe "getpeername"
   c_getpeername :: CInt -> Ptr sa -> Ptr CInt -> IO CInt

--- a/Network/Socket/Name.hs
+++ b/Network/Socket/Name.hs
@@ -21,7 +21,7 @@ getPeerName s =
    with (fromIntegral sz) $ \int_star -> do
      fd <- fdSocket s
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getPeerName" $
-       c_getpeername (fdSocket s) ptr int_star
+       c_getpeername fd ptr int_star
      peekSocketAddress ptr (Just int_star)
 
 -- | Getting my socket address.
@@ -31,7 +31,7 @@ getSocketName s =
    with (fromIntegral sz) $ \int_star -> do
      fd <- fdSocket s
      throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
-       c_getsockname (fdSocket s) ptr int_star
+       c_getsockname fd ptr int_star
      peekSocketAddress ptr (Just int_star)
 
 foreign import CALLCONV unsafe "getpeername"

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -182,7 +182,7 @@ accept s = withNewSocketAddress $ \sa sz -> do
                   nfd <- throwSocketErrorIfMinus1Retry "Network.Socket.accept" $
                     c_accept_safe fd sa ptr_len
                   addr' <- peekSocketAddress sa (Just ptr_len)
-                  return (nfd, Just addr')
+                  return (nfd, addr')
            else do
                 paramData <- c_newAcceptParams fd (fromIntegral sz) sa
                 rc        <- asyncDoProc c_acceptDoProc paramData
@@ -190,7 +190,8 @@ accept s = withNewSocketAddress $ \sa sz -> do
                 c_free paramData
                 when (rc /= 0) $
                      throwSocketErrorCode "Network.Socket.accept" (fromIntegral rc)
-                return (new_fd', Nothing)
+                addr' <- peekSocketAddress sa Nothing
+                return (new_fd', addr')
 #else
      with (fromIntegral sz) $ \ ptr_len -> do
 # ifdef HAVE_ADVANCED_SOCKET_FLAGS

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -176,11 +176,13 @@ accept :: SocketAddress sa => Socket -> IO (Socket, sa)
 accept s = withNewSocketAddress $ \sa sz -> do
      let fd = fdSocket s
 #if defined(mingw32_HOST_OS)
-     new_fd <-
+     (new_fd, addr) <-
         if threaded
-           then with (fromIntegral sz) $ \ ptr_len ->
-                  throwSocketErrorIfMinus1Retry "Network.Socket.accept" $
+           then with (fromIntegral sz) $ \ ptr_len -> do
+                  nfd <- throwSocketErrorIfMinus1Retry "Network.Socket.accept" $
                     c_accept_safe fd sa ptr_len
+                  addr' <- peekSocketAddress sa (Just ptr_len)
+                  return (nfd, Just addr')
            else do
                 paramData <- c_newAcceptParams fd (fromIntegral sz) sa
                 rc        <- asyncDoProc c_acceptDoProc paramData
@@ -188,7 +190,7 @@ accept s = withNewSocketAddress $ \sa sz -> do
                 c_free paramData
                 when (rc /= 0) $
                      throwSocketErrorCode "Network.Socket.accept" (fromIntegral rc)
-                return new_fd'
+                return (new_fd', Nothing)
 #else
      with (fromIntegral sz) $ \ ptr_len -> do
 # ifdef HAVE_ADVANCED_SOCKET_FLAGS
@@ -200,8 +202,8 @@ accept s = withNewSocketAddress $ \sa sz -> do
      setNonBlockIfNeeded new_fd
      setCloseOnExecIfNeeded new_fd
 # endif /* HAVE_ADVANCED_SOCKET_FLAGS */
+     addr <- peekSocketAddress sa (Just ptr_len)
 #endif
-     addr <- peekSocketAddress sa
      let new_s = mkSocket new_fd
      return (new_s, addr)
 

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -765,7 +765,7 @@ defaultPort = 0
 -- | The core typeclass to unify socket addresses.
 class SocketAddress sa where
     sizeOfSocketAddress :: sa -> Int
-    peekSocketAddress :: Ptr sa -> IO sa
+    peekSocketAddress :: Ptr sa -> Maybe (Ptr CInt) -> IO sa
     pokeSocketAddress  :: Ptr a -> sa -> IO ()
 
 withSocketAddress :: SocketAddress sa => sa -> (Ptr sa -> Int -> IO a) -> IO a
@@ -916,20 +916,27 @@ pokeSockAddr p (SockAddrInet6 (PortNum port) flow addr scope) = do
     (#poke struct sockaddr_in6, sin6_scope_id) p scope
 
 -- | Read a 'SockAddr' from the given memory location.
-peekSockAddr :: Ptr SockAddr -> IO SockAddr
-peekSockAddr p = do
+peekSockAddr :: Ptr SockAddr -> Maybe (Ptr CInt) -> IO SockAddr
+peekSockAddr p mLen  = do
   family <- (#peek struct sockaddr, sa_family) p
-  case family :: CSaFamily of
+  case (family :: CSaFamily, mLen) of
 #if defined(DOMAIN_SOCKET_SUPPORT)
-    (#const AF_UNIX) -> do
-        str <- peekCString ((#ptr struct sockaddr_un, sun_path) p)
+    ((#const AF_UNIX), Just pLen) -> do
+        -- Follow UNIX spec for potential non-null-terminated `sun_path`
+        addrlen <- peek pLen
+        let addr_ptr = (#ptr struct sockaddr_un, sun_path) p
+            str_len = addrlen - (#offset struct sockaddr_un, sun_path)
+        addr_len <- fromIntegral <$> strnlen addr_ptr str_len
+
+        -- Unix addresses cannot have encodings
+        str <- peekCAStringLen (addr_ptr, addr_len)
         return (SockAddrUnix str)
 #endif
-    (#const AF_INET) -> do
+    ((#const AF_INET), _) -> do
         addr <- (#peek struct sockaddr_in, sin_addr) p
         port <- (#peek struct sockaddr_in, sin_port) p
         return (SockAddrInet (PortNum port) addr)
-    (#const AF_INET6) -> do
+    ((#const AF_INET6), _) -> do
         port <- (#peek struct sockaddr_in6, sin6_port) p
         flow <- (#peek struct sockaddr_in6, sin6_flowinfo) p
         In6Addr addr <- (#peek struct sockaddr_in6, sin6_addr) p
@@ -1048,6 +1055,7 @@ instance Storable In6Addr where
 -- Helper functions
 
 foreign import ccall unsafe "string.h" memset :: Ptr a -> CInt -> CSize -> IO ()
+foreign import ccall unsafe "string.h" strnlen :: Ptr CChar -> CInt -> IO CSize
 
 -- | Zero a structure.
 zeroMemory :: Ptr a -> CSize -> IO ()

--- a/network.cabal
+++ b/network.cabal
@@ -97,6 +97,7 @@ test-suite spec
   build-depends:
     base < 5,
     bytestring,
+    directory,
     HUnit,
     network,
     hspec

--- a/tests/SimpleSpec.hs
+++ b/tests/SimpleSpec.hs
@@ -13,6 +13,8 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
 import Network.Socket
 import Network.Socket.ByteString
+import System.Directory
+import System.IO.Error
 import System.Timeout (timeout)
 
 import Test.Hspec
@@ -147,6 +149,15 @@ spec = do
                 `shouldBe` (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334)
 #endif
 
+    describe "unix sockets" $ do
+        it "basic unix sockets end-to-end" $ do
+            when isUnixDomainSocketAvailable $ do
+                let client sock = send sock testMsg
+                    server (sock, addr) = do
+                      recv sock 1024 `shouldReturn` testMsg
+                      addr `shouldBe` (SockAddrUnix "")
+                unixTest client server
+
 ------------------------------------------------------------------------
 
 serverAddr :: String
@@ -155,8 +166,38 @@ serverAddr = "127.0.0.1"
 testMsg :: ByteString
 testMsg = "This is a test message."
 
+unixAddr :: String
+unixAddr = "/tmp/network-test"
+
 ------------------------------------------------------------------------
 -- Test helpers
+
+-- | Establish a connection between client and server and then run
+-- 'clientAct' and 'serverAct', in different threads.  Both actions
+-- get passed a connected 'Socket', used for communicating between
+-- client and server.  'unixTest' makes sure that the 'Socket' is
+-- closed after the actions have run.
+unixTest :: (Socket -> IO a) -> ((Socket, SockAddr) -> IO b) -> IO ()
+unixTest clientAct serverAct = do
+    test clientSetup clientAct serverSetup server
+  where
+    clientSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        connect sock (SockAddrUnix unixAddr)
+        return sock
+
+    serverSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        bind sock (SockAddrUnix unixAddr)
+        listen sock 1
+        return sock
+
+    server sock = E.bracket (accept sock) (killClientSock . fst) serverAct
+
+    killClientSock sock = do
+        shutdown sock ShutdownBoth
+        close sock
+        E.tryJust (guard . isDoesNotExistError) $ removeFile unixAddr
 
 -- | Establish a connection between client and server and then run
 -- 'clientAct' and 'serverAct', in different threads.  Both actions


### PR DESCRIPTION
On certain linux distros, the returned sockaddr for a unix domain socket isn't guaranteed to be null terminated. This implements the recommended portable method to handle potentially non-null-terminated strings in `sun_path`.
See http://man7.org/linux/man-pages/man7/unix.7.html

The previous behavior would potentially read uninitialized memory and attempt to locale decode it

Test Plan: New unit test for unix domain sockets, which previously failed on centos

I would like to fix this for 2.6.3, but none of my dev environments can build the 2.6 branch.