### PR TITLE
Unix domain

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -919,7 +919,7 @@ withSockAddr addr f = do
 -- space.  This constant holds the maximum allowable path length.
 --
 unixPathMax :: Int
-unixPathMax = #const sizeof(((struct sockaddr_un *)0)->sun_path)
+unixPathMax = #const sizeof(((struct sockaddr_un *)NULL)->sun_path)
 
 -- We can't write an instance of 'Storable' for 'SockAddr' because
 -- @sockaddr@ is a sum type of variable size but

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -929,8 +929,8 @@ pokeSockAddr p (SockAddrUnix path) = do
 # endif
     (#poke struct sockaddr_un, sun_family) p ((#const AF_UNIX) :: CSaFamily)
     let pathC = map castCharToCChar path
-        poker = case path of ('\0':_) -> pokeArray; _ -> pokeArray0 0
-    poker ((#ptr struct sockaddr_un, sun_path) p) pathC
+    -- the buffer is already filled with nulls.
+    pokeArray ((#ptr struct sockaddr_un, sun_path) p) pathC
 #else
 pokeSockAddr _ SockAddrUnix{} = error "pokeSockAddr: not supported"
 #endif

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -820,7 +820,9 @@ withSocketAddress addr f = do
     allocaBytes sz $ \p -> pokeSocketAddress p addr >> f (castPtr p) sz
 
 withNewSocketAddress :: SocketAddress sa => (Ptr sa -> Int -> IO a) -> IO a
-withNewSocketAddress f = allocaBytes 128 $ \ptr -> f ptr 128
+withNewSocketAddress f = allocaBytes 128 $ \ptr -> do
+    zeroMemory ptr 128
+    f ptr 128
 
 ------------------------------------------------------------------------
 -- Socket addresses

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -966,7 +966,7 @@ peekSockAddr p = do
   case family :: CSaFamily of
 #if defined(DOMAIN_SOCKET_SUPPORT)
     (#const AF_UNIX) -> do
-        str <- peekCString ((#ptr struct sockaddr_un, sun_path) p)
+        str <- peekCAString ((#ptr struct sockaddr_un, sun_path) p)
         return (SockAddrUnix str)
 #endif
     (#const AF_INET) -> do

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -919,7 +919,11 @@ withSockAddr addr f = do
 -- space.  This constant holds the maximum allowable path length.
 --
 unixPathMax :: Int
+#if defined(DOMAIN_SOCKET_SUPPORT)
 unixPathMax = #const sizeof(((struct sockaddr_un *)NULL)->sun_path)
+#else
+unixPathMax = 0
+#endif
 
 -- We can't write an instance of 'Storable' for 'SockAddr' because
 -- @sockaddr@ is a sum type of variable size but

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -923,13 +923,7 @@ withSockAddr addr f = do
 pokeSockAddr :: Ptr a -> SockAddr -> IO ()
 #if defined(DOMAIN_SOCKET_SUPPORT)
 pokeSockAddr p (SockAddrUnix path) = do
-# if defined(darwin_HOST_OS)
     zeroMemory p (#const sizeof(struct sockaddr_un))
-# else
-    case path of
-      ('\0':_) -> zeroMemory p (#const sizeof(struct sockaddr_un))
-      _        -> return ()
-# endif
 # if defined(HAVE_STRUCT_SOCKADDR_SA_LEN)
     (#poke struct sockaddr_un, sun_len) p ((#const sizeof(struct sockaddr_un)) :: Word8)
 # endif
@@ -941,9 +935,7 @@ pokeSockAddr p (SockAddrUnix path) = do
 pokeSockAddr _ SockAddrUnix{} = error "pokeSockAddr: not supported"
 #endif
 pokeSockAddr p (SockAddrInet (PortNum port) addr) = do
-#if defined(darwin_HOST_OS)
     zeroMemory p (#const sizeof(struct sockaddr_in))
-#endif
 #if defined(HAVE_STRUCT_SOCKADDR_SA_LEN)
     (#poke struct sockaddr_in, sin_len) p ((#const sizeof(struct sockaddr_in)) :: Word8)
 #endif
@@ -951,9 +943,7 @@ pokeSockAddr p (SockAddrInet (PortNum port) addr) = do
     (#poke struct sockaddr_in, sin_port) p port
     (#poke struct sockaddr_in, sin_addr) p addr
 pokeSockAddr p (SockAddrInet6 (PortNum port) flow addr scope) = do
-# if defined(darwin_HOST_OS)
     zeroMemory p (#const sizeof(struct sockaddr_in6))
-# endif
 # if defined(HAVE_STRUCT_SOCKADDR_SA_LEN)
     (#poke struct sockaddr_in6, sin6_len) p ((#const sizeof(struct sockaddr_in6)) :: Word8)
 # endif

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -900,7 +900,7 @@ type CSaFamily = (#type sa_family_t)
 -- in that the value of the argument /is/ used.
 sizeOfSockAddr :: SockAddr -> Int
 #if defined(DOMAIN_SOCKET_SUPPORT)
-sizeOfSockAddr SockAddrUnix{}  = #const sizeof(struct sockaddr_un)
+sizeOfSockAddr SockAddrUnix{}  = sockaddrStorageLen
 #else
 sizeOfSockAddr SockAddrUnix{}  = error "sizeOfSockAddr: not supported"
 #endif

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -814,15 +814,20 @@ class SocketAddress sa where
     peekSocketAddress :: Ptr sa -> IO sa
     pokeSocketAddress  :: Ptr a -> sa -> IO ()
 
+-- sizeof(struct sockaddr_storage) which has enough space to contain
+-- sockaddr_in, sockaddr_in6 and sockaddr_un.
+sockaddrStorageLen :: Int
+sockaddrStorageLen = 128
+
 withSocketAddress :: SocketAddress sa => sa -> (Ptr sa -> Int -> IO a) -> IO a
 withSocketAddress addr f = do
     let sz = sizeOfSocketAddress addr
     allocaBytes sz $ \p -> pokeSocketAddress p addr >> f (castPtr p) sz
 
 withNewSocketAddress :: SocketAddress sa => (Ptr sa -> Int -> IO a) -> IO a
-withNewSocketAddress f = allocaBytes 128 $ \ptr -> do
-    zeroMemory ptr 128
-    f ptr 128
+withNewSocketAddress f = allocaBytes sockaddrStorageLen $ \ptr -> do
+    zeroMemory ptr $ fromIntegral sockaddrStorageLen
+    f ptr sockaddrStorageLen
 
 ------------------------------------------------------------------------
 -- Socket addresses

--- a/network.cabal
+++ b/network.cabal
@@ -97,6 +97,7 @@ test-suite spec
   build-depends:
     base < 5,
     bytestring,
+    directory,
     HUnit,
     network,
     hspec

--- a/tests/SimpleSpec.hs
+++ b/tests/SimpleSpec.hs
@@ -13,6 +13,8 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
 import Network.Socket
 import Network.Socket.ByteString
+import System.Directory
+import System.IO.Error
 import System.Timeout (timeout)
 
 import Test.Hspec
@@ -147,6 +149,15 @@ spec = do
                 `shouldBe` (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334)
 #endif
 
+    describe "unix sockets" $ do
+        it "basic unix sockets end-to-end" $ do
+            when isUnixDomainSocketAvailable $ do
+                let client sock = send sock testMsg
+                    server (sock, addr) = do
+                      recv sock 1024 `shouldReturn` testMsg
+                      addr `shouldBe` (SockAddrUnix "")
+                unixTest client server
+
 ------------------------------------------------------------------------
 
 serverAddr :: String
@@ -155,8 +166,38 @@ serverAddr = "127.0.0.1"
 testMsg :: ByteString
 testMsg = "This is a test message."
 
+unixAddr :: String
+unixAddr = "/tmp/network-test"
+
 ------------------------------------------------------------------------
 -- Test helpers
+
+-- | Establish a connection between client and server and then run
+-- 'clientAct' and 'serverAct', in different threads.  Both actions
+-- get passed a connected 'Socket', used for communicating between
+-- client and server.  'unixTest' makes sure that the 'Socket' is
+-- closed after the actions have run.
+unixTest :: (Socket -> IO a) -> ((Socket, SockAddr) -> IO b) -> IO ()
+unixTest clientAct serverAct = do
+    test clientSetup clientAct serverSetup server
+  where
+    clientSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        connect sock (SockAddrUnix unixAddr)
+        return sock
+
+    serverSetup = do
+        sock <- socket AF_UNIX Stream defaultProtocol
+        bind sock (SockAddrUnix unixAddr)
+        listen sock 1
+        return sock
+
+    server sock = E.bracket (accept sock) (killClientSock . fst) serverAct
+
+    killClientSock sock = do
+        shutdown sock ShutdownBoth
+        close sock
+        E.tryJust (guard . isDoesNotExistError) $ removeFile unixAddr
 
 -- | Establish a connection between client and server and then run
 -- 'clientAct' and 'serverAct', in different threads.  Both actions


### PR DESCRIPTION
Cc: @vdukhovni @JonCoens

Fix: `accept` should return `SockAddrUnix ""` for unix domain sockets.

- 4e257c56dcb48a8d000d240dc53cf4bf97fea4c3 is a test case created by @JonCoens. It shows that the bug exists.
- adc9f8b0665d1368edb38bd1c08a5456c0a600ae is a fix for the bug.
- My concern is `#const sizeof(struct sockaddr_un)`. If we add 1 to this size, the tests fail.