### PR TITLE
Update network 2.7 no buildinfo callconv

### DIFF
--- a/Network/BSD.hsc
+++ b/Network/BSD.hsc
@@ -17,6 +17,7 @@
 -----------------------------------------------------------------------------
 
 #include "HsNet.h"
+##include "HsNetDef.h"
 
 module Network.BSD  {-# DEPRECATED "This platform dependent module is no longer supported." #-}
     (

--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -91,8 +91,7 @@
 -----------------------------------------------------------------------------
 
 #include "HsNet.h"
-
--- In order to process this file, you need to have CALLCONV defined.
+##include "HsNetDef.h"
 
 module Network.Socket
     (

--- a/Network/Socket/Internal.hsc
+++ b/Network/Socket/Internal.hsc
@@ -19,6 +19,7 @@
 -----------------------------------------------------------------------------
 
 #include "HsNet.h"
+##include "HsNetDef.h"
 
 module Network.Socket.Internal
     (

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -3,6 +3,7 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
 #include "HsNet.h"
+##include "HsNetDef.h"
 
 module Network.Socket.Types
     (

--- a/configure.ac
+++ b/configure.ac
@@ -173,12 +173,15 @@ case "$host" in
 *-mingw* | *-msys*)
 	EXTRA_SRCS="cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c"
 	EXTRA_LIBS=ws2_32
+	;;
 *-solaris2*)
 	EXTRA_SRCS="cbits/ancilData.c"
 	EXTRA_LIBS="nsl, socket"
+	;;
 *)
 	EXTRA_SRCS="cbits/ancilData.c"
 	EXTRA_LIBS=
+	;;
 esac
 AC_SUBST([EXTRA_CPPFLAGS])
 AC_SUBST([EXTRA_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,7 @@ else
 fi
 
 dnl --------------------------------------------------
-dnl * test for GETPEEREID(3) 
+dnl * test for GETPEEREID(3)
 dnl --------------------------------------------------
 AC_MSG_CHECKING(for getpeereid in unistd.h)
 AC_CHECK_FUNC( getpeereid, AC_DEFINE([HAVE_GETPEEREID], [1], [Define to 1 if you have getpeereid.] ))
@@ -173,17 +173,13 @@ case "$host" in
 *-mingw* | *-msys*)
 	EXTRA_SRCS="cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c"
 	EXTRA_LIBS=ws2_32
-	CALLCONV=stdcall ;;
 *-solaris2*)
 	EXTRA_SRCS="cbits/ancilData.c"
 	EXTRA_LIBS="nsl, socket"
-	CALLCONV=ccall ;;
 *)
 	EXTRA_SRCS="cbits/ancilData.c"
 	EXTRA_LIBS=
-	CALLCONV=ccall ;;
 esac
-AC_SUBST([CALLCONV])
 AC_SUBST([EXTRA_CPPFLAGS])
 AC_SUBST([EXTRA_LIBS])
 AC_SUBST([EXTRA_SRCS])

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -7,18 +7,11 @@
 #ifndef HSNET_H
 #define HSNET_H
 
-#include "HsNetworkConfig.h"
+#include "HsNetDef.h"
 
 #ifdef NEED_WINVER
 # define WINVER 0x0501
 #endif
-
-/* ultra-evil... */
-#undef PACKAGE_BUGREPORT
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
 
 #ifndef INLINE
 # if defined(_MSC_VER)
@@ -159,22 +152,6 @@ hsnet_freeaddrinfo(struct addrinfo *ai)
 {
     freeaddrinfo(ai);
 }
-#endif
-
-#if defined(HAVE_WINSOCK2_H)
-# define WITH_WINSOCK  1
-#endif
-
-#if !defined(mingw32_HOST_OS) && !defined(_WIN32)
-# define DOMAIN_SOCKET_SUPPORT 1
-#endif
-
-#if !defined(CALLCONV)
-# if defined(WITH_WINSOCK)
-#  define CALLCONV stdcall
-# else
-#  define CALLCONV ccall
-# endif
 #endif
 
 #if !defined(IOV_MAX)

--- a/include/HsNetDef.h
+++ b/include/HsNetDef.h
@@ -1,0 +1,33 @@
+#ifndef HSNETDEF_H
+#define HSNETDEF_H
+
+#include "HsNetworkConfig.h"
+
+/* ultra-evil... */
+#undef PACKAGE_BUGREPORT
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+#undef PACKAGE_TARNAME
+#undef PACKAGE_VERSION
+
+#if defined(HAVE_WINSOCK2_H)
+# define WITH_WINSOCK  1
+#endif
+
+#if !defined(mingw32_HOST_OS) && !defined(_WIN32)
+# define DOMAIN_SOCKET_SUPPORT 1
+#endif
+
+#if defined(WITH_WINSOCK)
+# define CALLCONV stdcall
+#else
+# define CALLCONV ccall
+#endif
+
+#if defined(mingw32_HOST_OS)
+# define SAFE_ON_WIN safe
+#else
+# define SAFE_ON_WIN unsafe
+#endif
+
+#endif /* HSNETDEF_H */

--- a/include/HsNetDef.h
+++ b/include/HsNetDef.h
@@ -18,12 +18,24 @@
 # define DOMAIN_SOCKET_SUPPORT 1
 #endif
 
-#if defined(WITH_WINSOCK)
-# define CALLCONV stdcall
+/* stdcall is for Windows 32.
+   Haskell FFI does not have a keyword for Windows 64.
+   If ccall/stdcall is specified on Windows 64,
+   GHC ignores it and use a proper ABI for Windows 64.
+   But if stdcall is specified, GHC displays a warning.
+   So, let's use ccall for Windows 64.
+ */
+#if defined(mingw32_HOST_OS)
+# if defined(i386_HOST_ARCH)
+#  define CALLCONV stdcall
+# elif defined(x86_64_HOST_ARCH)
+#  define CALLCONV ccall
+# else
+#  error Unknown mingw32 arch
+# endif
 #else
 # define CALLCONV ccall
 #endif
-
 #if defined(mingw32_HOST_OS)
 # define SAFE_ON_WIN safe
 #else

--- a/network.buildinfo.in
+++ b/network.buildinfo.in
@@ -1,7 +1,7 @@
-ghc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
-ghc-prof-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
+ghc-options: @EXTRA_CPPFLAGS@
+ghc-prof-options: @EXTRA_CPPFLAGS@
 ld-options: @LDFLAGS@
-cc-options: -DCALLCONV=@CALLCONV@ @EXTRA_CPPFLAGS@
+cc-options: @EXTRA_CPPFLAGS@
 c-sources: @EXTRA_SRCS@
 extra-libraries: @EXTRA_LIBS@
 install-includes: HsNetworkConfig.h

--- a/network.cabal
+++ b/network.cabal
@@ -24,7 +24,7 @@ extra-source-files:
   README.md CHANGELOG.md
   examples/*.hs tests/*.hs config.guess config.sub install-sh
   configure.ac configure network.buildinfo.in
-  include/HsNetworkConfig.h.in include/HsNet.h
+  include/HsNetworkConfig.h.in include/HsNet.h include/HsDef.h
   -- C sources only used on some systems
   cbits/ancilData.c cbits/asyncAccept.c cbits/initWinSock.c
   cbits/winSockErr.c

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,6 @@
 resolver: lts-9.18
 packages:
 - '.'
-ghc-options:
-  "*": -DCALLCONV=ccall
 nix:
   packages: [ ncurses ]
 


### PR DESCRIPTION
This updated the `2.7` branch to remove the need to specify `callconv` inside `buildinfo` just like the `master` branch.

This works around a stack issue where the incorrect `sed` is used.

Fixes #313