### PR TITLE
Reduce dependency on configure

### DIFF
--- a/cbits/asyncAccept.c
+++ b/cbits/asyncAccept.c
@@ -5,14 +5,14 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H)
+#if defined(_WIN32)
 
 /* all the way to the end */
 
 /*
  * To support non-blocking accept()s with WinSock, we use the asyncDoProc#
  * primop, which lets a Haskell thread call an external routine without
- * blocking the progress of other threads. 
+ * blocking the progress of other threads.
  *
  * As can readily be seen, this is a low-level mechanism.
  *
@@ -26,7 +26,7 @@ typedef struct AcceptData {
 } AcceptData;
 
 /*
- * Fill in parameter block that's passed along when the RTS invokes the 
+ * Fill in parameter block that's passed along when the RTS invokes the
  * accept()-calling proc below (acceptDoProc())
  */
 void*
@@ -40,7 +40,7 @@ newAcceptParams(int sock,
     data->newSock  = 0;
     data->sockAddr = sockaddr;
     data->size     = sz;
-    
+
     return data;
 }
 

--- a/cbits/initWinSock.c
+++ b/cbits/initWinSock.c
@@ -1,7 +1,7 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H)
+#if defined(_WIN32)
 
 static int winsock_inited = 0;
 
@@ -16,14 +16,14 @@ int
 initWinSock ()
 {
   WORD wVersionRequested;
-  WSADATA wsaData;  
+  WSADATA wsaData;
   int err;
 
   if (!winsock_inited) {
     wVersionRequested = MAKEWORD( 2, 2 );
 
     err = WSAStartup ( wVersionRequested, &wsaData );
-    
+
     if ( err != 0 ) {
        return err;
     }

--- a/cbits/winSockErr.c
+++ b/cbits/winSockErr.c
@@ -1,7 +1,7 @@
 #include "HsNet.h"
 #include "HsFFI.h"
 
-#if defined(HAVE_WINSOCK2_H)
+#if defined(_WIN32)
 #include <stdio.h>
 
 /* to the end */

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,4 @@ AC_CHECK_DECLS([SO_PEERCRED])
 AC_CHECK_MEMBERS([struct msghdr.msg_control, struct msghdr.msg_accrights])
 AC_CHECK_MEMBERS([struct sockaddr.sa_len])
 
-AC_CONFIG_FILES([HsNetworkConfig.h])
-
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,8 @@ dnl See also HsNet.h
 ac_includes_default="#define _GNU_SOURCE 1  /* for struct ucred on Linux */
 $ac_includes_default
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef _WIN32
 # include <winsock2.h>
-#endif
-#ifdef HAVE_WS2TCPIP_H
 # include <ws2tcpip.h>
 # define IPV6_V6ONLY 27
 #endif
@@ -72,7 +70,6 @@ AC_PROG_CC()
 
 AC_C_CONST
 
-AC_CHECK_HEADERS([winsock2.h ws2tcpip.h])
 AC_CHECK_HEADERS([limits.h stdlib.h unistd.h sys/types.h fcntl.h])
 AC_CHECK_HEADERS([sys/uio.h sys/socket.h netinet/in.h netinet/tcp.h])
 AC_CHECK_HEADERS([sys/un.h arpa/inet.h netdb.h])
@@ -90,26 +87,5 @@ AC_CHECK_DECLS([SO_PEERCRED])
 
 AC_CHECK_MEMBERS([struct msghdr.msg_control, struct msghdr.msg_accrights])
 AC_CHECK_MEMBERS([struct sockaddr.sa_len])
-
-AC_CHECK_LIB(ws2_32, _head_libws2_32_a)
-
-case "$host" in
-*-mingw* | *-msys*)
-	EXTRA_SRCS="cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c"
-	EXTRA_LIBS=ws2_32 ;;
-*-solaris2*)
-	EXTRA_SRCS="cbits/ancilData.c"
-	EXTRA_LIBS="nsl, socket" ;;
-*)
-	EXTRA_SRCS="cbits/ancilData.c"
-	EXTRA_LIBS= ;;
-esac
-
-AC_SUBST([CALLCONV])
-AC_SUBST([EXTRA_CPPFLAGS])
-AC_SUBST([EXTRA_LIBS])
-AC_SUBST([EXTRA_SRCS])
-
-AC_CONFIG_FILES([network.buildinfo])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -88,4 +88,6 @@ AC_CHECK_DECLS([SO_PEERCRED])
 AC_CHECK_MEMBERS([struct msghdr.msg_control, struct msghdr.msg_accrights])
 AC_CHECK_MEMBERS([struct sockaddr.sa_len])
 
+AC_CONFIG_FILES([HsNetworkConfig.h])
+
 AC_OUTPUT

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -21,10 +21,8 @@
 
 #define _GNU_SOURCE 1 /* for struct ucred on Linux */
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef _WIN32
 # include <winsock2.h>
-#endif
-#ifdef HAVE_WS2TCPIP_H
 # include <ws2tcpip.h>
 # define IPV6_V6ONLY 27
 #endif
@@ -72,7 +70,7 @@
 # include <netioapi.h>
 #endif
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef _WIN32
 extern int   initWinSock ();
 extern const char* getWSErrorDescr(int err);
 extern void* newAcceptParams(int sock,
@@ -80,17 +78,17 @@ extern void* newAcceptParams(int sock,
 			     void* sockaddr);
 extern int   acceptNewSock(void* d);
 extern int   acceptDoProc(void* param);
-#else  /* HAVE_WINSOCK2_H */
+#else  /* _WIN32 */
 extern int
 sendFd(int sock, int outfd);
 
 extern int
 recvFd(int sock);
-#endif /* HAVE_WINSOCK2_H */
+#endif /* _WIN32 */
 
 INLINE char *
 hsnet_inet_ntoa(
-#if defined(HAVE_WINSOCK2_H)
+#if defined(_WIN32)
              u_long addr
 #elif defined(HAVE_IN_ADDR_T)
              in_addr_t addr
@@ -108,7 +106,7 @@ hsnet_inet_ntoa(
 
 INLINE int
 hsnet_getnameinfo(const struct sockaddr* a,socklen_t b, char* c,
-# if defined(HAVE_WINSOCK2_H)
+# if defined(_WIN32)
                   DWORD d, char* e, DWORD f, int g)
 # else
                   socklen_t d, char* e, socklen_t f, int g)

--- a/network.buildinfo.in
+++ b/network.buildinfo.in
@@ -1,7 +1,0 @@
-ghc-options: @EXTRA_CPPFLAGS@
-ghc-prof-options: @EXTRA_CPPFLAGS@
-ld-options: @LDFLAGS@
-cc-options: @EXTRA_CPPFLAGS@
-c-sources: @EXTRA_SRCS@
-extra-libraries: @EXTRA_LIBS@
-install-includes: HsNetworkConfig.h

--- a/network.cabal
+++ b/network.cabal
@@ -69,7 +69,7 @@ library
 
   include-dirs: include
   includes: HsNet.h HsNetDef.h
-  install-includes: HsNet.h HsNetDef.h HsNetworkConfig.h
+  install-includes: HsNet.h HsNetDef.h include/HsNetworkConfig.h
   c-sources: cbits/HsNet.c
   ghc-options: -Wall -fwarn-tabs
 

--- a/network.cabal
+++ b/network.cabal
@@ -23,7 +23,7 @@ extra-tmp-files:
 extra-source-files:
   README.md CHANGELOG.md
   examples/*.hs tests/*.hs config.guess config.sub install-sh
-  configure.ac configure network.buildinfo.in
+  configure.ac configure
   include/HsNetworkConfig.h.in include/HsNet.h include/HsNetDef.h
   -- C sources only used on some systems
   cbits/ancilData.c cbits/asyncAccept.c cbits/initWinSock.c
@@ -68,8 +68,8 @@ library
     bytestring < 0.11
 
   include-dirs: include
-  includes: HsNet.h HsNetDef.h
-  install-includes: HsNet.h HsNetDef.h include/HsNetworkConfig.h
+  includes: HsNet.h HsNetDef.h HsNetworkConfig.h
+  install-includes: HsNet.h HsNetDef.h HsNetworkConfig.h
   c-sources: cbits/HsNet.c
   ghc-options: -Wall -fwarn-tabs
 

--- a/network.cabal
+++ b/network.cabal
@@ -68,8 +68,8 @@ library
     bytestring < 0.11
 
   include-dirs: include
-  includes: HsNet.h HsNetDef.h HsNetworkConfig.h
-  install-includes: HsNet.h HsNetDef.h HsNetworkConfig.h
+  includes: HsNet.h HsNetDef.h
+  install-includes: HsNet.h HsNetDef.h
   c-sources: cbits/HsNet.c
   ghc-options: -Wall -fwarn-tabs
 

--- a/network.cabal
+++ b/network.cabal
@@ -92,7 +92,6 @@ library
       Network.Socket.ByteString.Lazy.Windows
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
     extra-libraries: ws2_32
-    cc-options: -DWINVER=0x0600 -D_WIN32_WINNT=0x0600
 
 test-suite spec
   default-language: Haskell2010

--- a/network.cabal
+++ b/network.cabal
@@ -63,28 +63,35 @@ library
     Network.Socket.Types
     Network.Socket.Unix
 
+  build-depends:
+    base >= 4.6 && < 5,
+    bytestring < 0.11
+
+  include-dirs: include
+  includes: HsNet.h HsNetDef.h
+  install-includes: HsNet.h HsNetDef.h HsNetworkConfig.h
+  c-sources: cbits/HsNet.c
+  ghc-options: -Wall -fwarn-tabs
+
+
+  -- Add some platform specific stuff
   if !os(windows)
     other-modules:
       Network.Socket.ByteString.IOVec
       Network.Socket.ByteString.Lazy.Posix
       Network.Socket.ByteString.MsgHdr
+    build-depends:
+      unix >= 2
+    c-sources: cbits/ancilData.c
+
+  if os(solaris)
+    extra-libraries: nsl, socket
+
   if os(windows)
     other-modules:
       Network.Socket.ByteString.Lazy.Windows
-
-  build-depends:
-    base >= 4.6 && < 5,
-    bytestring < 0.11
-
-  if !os(windows)
-    build-depends:
-      unix >= 2
-
-  include-dirs: include
-  includes: HsNet.h HsNetDef.h
-  install-includes: HsNet.h HsNetDef.h
-  c-sources: cbits/HsNet.c
-  ghc-options: -Wall -fwarn-tabs
+    c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
+    extra-libraries: ws2_32
 
 test-suite spec
   default-language: Haskell2010

--- a/network.cabal
+++ b/network.cabal
@@ -92,6 +92,7 @@ library
       Network.Socket.ByteString.Lazy.Windows
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
     extra-libraries: ws2_32
+    cc-options: -DWINVER=0x0600 -D_WIN32_WINNT=0x0600
 
 test-suite spec
   default-language: Haskell2010


### PR DESCRIPTION
I'd like to reduce the dependency on autoconf, particularly on Windows.

Currently network does header and library tests for Windows. The library test will always fail since mingw-w64 named the internal symbol it's checking for differently than mingw. Also the test will also not work when using the native Windows sdk.

The header tests are problematic since they require users to have the GCC we bundle with GHC on the path, if they don't, network will build, but it won't link.  This has been a really confusing thing for users. This case will give them a compile error instead with a much more obvious error.

The header and library tests aren't needed as they are pretty ubiquitous. Every single Windows OS since 95 has included Winsock2 support. As for newer functionality, runtime tests are preferred here. 

Getting rid of `buildinfo` also permanently solves the paths problem with grep and numerical folders on the path. So building network will fail less often. The platform specific stuff have all been moved into the cabal file, which already did some platform checks. Now it's all only in the cabal file.

Eventually I want to get rid of configure completely for network on Windows, to make it much easier to install. This is the first step towards that.

Thoughts?