### PR TITLE
Fix Network.Socket.ByteString.Lazy.sendAll hang

### DIFF
--- a/Network/Socket/ByteString/Lazy/Posix.hs
+++ b/Network/Socket/ByteString/Lazy/Posix.hs
@@ -50,7 +50,9 @@ sendAll
     :: Socket -- ^ Connected socket
     -> L.ByteString -- ^ Data to send
     -> IO ()
-sendAll s bs = do
-    sent <- send s bs
-    waitWhen0 (fromIntegral sent) s
-    when (sent >= 0) $ sendAll s $ L.drop sent bs
+sendAll s bs
+    | L.null bs = return ()
+    | otherwise = do
+        sent <- send s bs
+        waitWhen0 (fromIntegral sent) s
+        when (sent >= 0) $ sendAll s $ L.drop sent bs

--- a/Network/Socket/ByteString/Lazy/Windows.hs
+++ b/Network/Socket/ByteString/Lazy/Windows.hs
@@ -26,7 +26,9 @@ sendAll
     :: Socket -- ^ Connected socket
     -> L.ByteString -- ^ Data to send
     -> IO ()
-sendAll s bs = do
-    sent <- send s bs
-    waitWhen0 (fromIntegral sent) s
-    when (sent >= 0) $ sendAll s $ L.drop sent bs
+sendAll s bs
+    | L.null bs = return ()
+    | otherwise = do
+        sent <- send s bs
+        waitWhen0 (fromIntegral sent) s
+        when (sent >= 0) $ sendAll s $ L.drop sent bs

--- a/tests/SimpleSpec.hs
+++ b/tests/SimpleSpec.hs
@@ -11,8 +11,10 @@ import Control.Monad
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Lazy as L
 import Network.Socket
 import Network.Socket.ByteString
+import qualified Network.Socket.ByteString.Lazy as Lazy
 import System.Directory
 import System.Timeout (timeout)
 
@@ -182,6 +184,12 @@ spec = do
                       recv sock 1024 `shouldReturn` testMsg
                       addr `shouldBe` (SockAddrUnix "")
                 unixTest client server
+
+    describe "Lazy.sendAll" $ do
+        it "works well" $ do
+            let server sock = recv sock 1024 `shouldReturn` testMsg
+                client sock = Lazy.sendAll sock $ L.fromChunks [testMsg]
+            tcpTest client server
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
The issue is that `(sent >= 0)` will always return `True` in recursive calls to `sendAll`, so we need a check to prevent that -- otherwise calling `sendAll` will _always_ diverge.