### PR TITLE
Add SockAddr NFData instance

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -69,6 +69,7 @@ import Foreign.C.Error (throwErrno)
 import Foreign.Marshal.Alloc
 import GHC.Conc (closeFdWith)
 import System.Posix.Types (Fd)
+import Control.DeepSeq (NFData (..))
 
 #if defined(DOMAIN_SOCKET_SUPPORT)
 import Foreign.Marshal.Array
@@ -905,6 +906,10 @@ data SockAddr
   | SockAddrUnix
         String           -- sun_path
   deriving (Eq, Ord, Typeable)
+
+instance NFData SockAddr where
+  rnf (SockAddrUnix str) = rnf str
+  rnf _ = ()
 
 -- | Is the socket address type supported on this system?
 isSupportedSockAddr :: SockAddr -> Bool

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -908,8 +908,9 @@ data SockAddr
   deriving (Eq, Ord, Typeable)
 
 instance NFData SockAddr where
+  rnf (SockAddrInet _ _) = ()
+  rnf (SockAddrInet6 _ _ _ _) = ()
   rnf (SockAddrUnix str) = rnf str
-  rnf _ = ()
 
 -- | Is the socket address type supported on this system?
 isSupportedSockAddr :: SockAddr -> Bool

--- a/network.cabal
+++ b/network.cabal
@@ -64,7 +64,8 @@ library
 
   build-depends:
     base >= 4.7 && < 5,
-    bytestring == 0.10.*
+    bytestring == 0.10.*,
+    deepseq
 
   include-dirs: include
   includes: HsNet.h HsNetDef.h


### PR DESCRIPTION
This PR simply adds an `NFData` instance to the `SockAddr` type.

I think this instance is correct, since all the other constructors have only completely strict fields. Please, let me know if I'm wrong.

The `deepseq` package is added to the dependency list, but we are already depending on it transitively through the `bytestring` package. I left the version blank because I could not decide. I'm open to suggestions.

Thanks for your review.