### PR TITLE
Improve network package description

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -7,10 +7,23 @@ synopsis:       Low-level networking interface
 description:
   This package provides a low-level networking interface.
   .
-  In network-2.6 the @Network.URI@ module was split off into its own
-  package, network-uri-2.6. If you're using the @Network.URI@ module
-  you can automatically get it from the right package by adding this
-  to your .cabal file:
+  === High-Level Packages
+  Other packages provide higher level interfaces:
+  .
+  * connection
+  * hookup
+  * network-simple
+  .
+  === Related Packages
+  ==== @network-bsd@
+  In @network-3.0.0.0@ the @Network.BSD@ module was split off into its own
+  package, @network-bsd-3.0.0.0@.
+  .
+  ==== @network-uri@
+  In @network-2.6@ the @Network.URI@ module was split off into its own package,
+  @network-uri-2.6@. If you're using the @Network.URI@ module you can
+  automatically get it from the right package by adding this to your @.cabal@
+  file:
   .
   > library
   >   build-depends: network-uri-flag


### PR DESCRIPTION
Previous discussion: https://github.com/haskell/network/issues/343

Network's existence as a low level wrapper around C apis has been well
established and recently cemented with official deprecation of the
Network module. This decision left a hole in the ecosystem that has been
filled by many downstream libraries. For most use cases network is far
too low level and many higher level libraries are far more appropriate,
yet network still has high traction and continues to draw users who are
confused or mystified by how low level the library is. Part of the
problem is the package's description on hackage.

>  This package provides a low-level networking interface.
>  .
>  In network-2.6 the @Network.URI@ module was split off into its own
>  package, network-uri-2.6. If you're using the @Network.URI@ module
>  you can automatically get it from the right package by adding this
>  to your .cabal file:
>  .
>  > library
>  > build-depends: network-uri-flag

This description leaves much to be desired. It only has a single
sentence describing what network is and then spends much more detail in
pointing users to a historic package split. This description is a lost
opportunity for the ecosystem. A reverse dependency lookup shows many
downstream consumers of network, but only a few of these are high level
libraries appropriate for most application developers. network could use
its package description to highlight notable packages that are higher
level and have easier ergonomics, such as the connection library. This
would provide a much simpler path for most users to leverage socket
programming in Haskell.

Through disscussion 3 packages were identified as appropriate to
enumerate:

* connection
* hookup
* network simple

These packages follow the simple rule that they:

* depend on network.
* expose a subset of network's functionality.