### PR TITLE
Remove EOF errors from receive functions

### DIFF
--- a/Network/Socket/ByteString/IO.hsc
+++ b/Network/Socket/ByteString/IO.hsc
@@ -43,14 +43,12 @@ module Network.Socket.ByteString.IO
     ) where
 
 import Control.Concurrent (threadWaitWrite, rtsSupportsBoundThreads)
-import Control.Exception as E (catch, throwIO)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.ByteString.Internal (createAndTrim)
 import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
 import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Ptr (castPtr)
-import System.IO.Error (isEOFError)
 
 import Network.Socket.Buffer
 import Network.Socket.ByteString.Internal
@@ -220,10 +218,7 @@ recv :: Socket        -- ^ Connected socket
      -> IO ByteString  -- ^ Data received
 recv s nbytes
     | nbytes < 0 = ioError (mkInvalidRecvArgError "Network.Socket.ByteString.recv")
-    | otherwise  = createAndTrim nbytes $ \ptr ->
-        E.catch
-          (recvBuf s ptr nbytes)
-          (\e -> if isEOFError e then return 0 else throwIO e)
+    | otherwise  = createAndTrim nbytes $ \ptr -> recvBuf s ptr nbytes
 
 -- | Receive data from the socket.  The socket need not be in a
 -- connected state.  Returns @(bytes, address)@ where @bytes@ is a


### PR DESCRIPTION
I'm opening this as an RFC. Please let me know what your thoughts are.

It is generally accepted that EOF errors in `Network` were a mistake.
Using exceptions for control flow is an anti-pattern in the Haskell
community. While we are in the process of introducing epoch breaking
changes it makes sense to attempt to remove these historic accidents.

There should really be no perceived change for users of
`Network.ByteString(.Lazy).recv`, however `recvFrom` does change
behavior. There are two key differences in `recvFrom`:

1. It is now returning a `(0, address)` on an EOF.
2. It will peek the socket's address and `getPeerName` on an EOF. This
    has some implications for performance, and such may be controversial.

The second point poses a question. Does the return type of
`SocketAddress sa => IO (Int, sa)` make sense for `recvBufFrom`?