### PR TITLE
doctest with cabal-doctest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,7 @@ matrix:
 before_install:
  - HC=${CC}
  - unset CC
-# For GHC 7.10.3
-# "The program 'hsc2hs' is required but it could not be found "
-# See https://github.com/haskell-CI/haskell-ci/issues/66
- - HCVER=`echo $HC | sed 's/ghc-//'`
- - "PATH=/opt/ghc/${HCVER}/bin:/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH"
+ - "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH"
  - echo $PATH
  - PKGNAME='network'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,6 @@ script:
  # build & run tests
  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
 
- # we can't run `test:doctest` currently, so let's run only the other two testsuites
- #- if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
-
- - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} test:spec; fi
+ - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ matrix:
     - compiler: "ghc-8.4.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.2"
+    - compiler: "ghc-8.6.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-head"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
@@ -53,7 +53,12 @@ matrix:
 before_install:
  - HC=${CC}
  - unset CC
- - PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
+# For GHC 7.10.3
+# "The program 'hsc2hs' is required but it could not be found "
+# See https://github.com/haskell-CI/haskell-ci/issues/66
+ - HCVER=`echo $HC | sed 's/ghc-//'`
+ - "PATH=/opt/ghc/${HCVER}/bin:/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH"
+ - echo $PATH
  - PKGNAME='network'
 
 install:
@@ -66,9 +71,10 @@ install:
  - rm -fv cabal.project.local
  - "echo 'packages: .' > cabal.project"
  - rm -f cabal.project.freeze
+ - cabal install hspec-discover
+ - cabal install cabal-doctest
  - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
- - cabal install hspec-discover
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -351,10 +351,12 @@ withCStringIf True  n f = allocaBytes n (f (fromIntegral n))
 -- If the query fails, this function throws an IO exception.
 --
 -- >>> addr:_ <- getAddrInfo (Just defaultHints) (Just "127.0.0.1") (Just "http")
--- >>> getNameInfo [] True True $ addrAddress addr
--- (Just "localhost",Just "http")
 -- >>> getNameInfo [NI_NUMERICHOST, NI_NUMERICSERV] True True $ addrAddress addr
 -- (Just "127.0.0.1",Just "80")
+{-
+-- >>> getNameInfo [] True True $ addrAddress addr
+-- (Just "localhost",Just "http")
+-}
 getNameInfo
     :: [NameInfoFlag] -- ^ flags to control lookup behaviour
     -> Bool -- ^ whether to look up a hostname

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -1045,7 +1045,7 @@ type HostAddress = Word32
 -- For example for @127.0.0.1@ the function will return @(0x7f, 0, 0, 1)@
 -- regardless of host endianness.
 --
--- prop> tow == hostAddressToTuple (tupleToHostAddress tow)
+{- -- prop> tow == hostAddressToTuple (tupleToHostAddress tow) -}
 hostAddressToTuple :: HostAddress -> (Word8, Word8, Word8, Word8)
 hostAddressToTuple ha' =
     let ha = htonl ha'
@@ -1066,7 +1066,7 @@ type HostAddress6 = (Word32, Word32, Word32, Word32)
 
 -- | Converts 'HostAddress6' to representation-independent IPv6 octuple.
 --
--- prop> (w1,w2,w3,w4,w5,w6,w7,w8) == hostAddress6ToTuple (tupleToHostAddress6 (w1,w2,w3,w4,w5,w6,w7,w8))
+{- -- prop> (w1,w2,w3,w4,w5,w6,w7,w8) == hostAddress6ToTuple (tupleToHostAddress6 (w1,w2,w3,w4,w5,w6,w7,w8)) -}
 hostAddress6ToTuple :: HostAddress6 -> (Word16, Word16, Word16, Word16,
                                         Word16, Word16, Word16, Word16)
 hostAddress6ToTuple (w3, w2, w1, w0) =

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,33 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wall #-}
 module Main (main) where
+
+#ifndef MIN_VERSION_cabal_doctest
+#define MIN_VERSION_cabal_doctest(x,y,z) 0
+#endif
+
+#if MIN_VERSION_cabal_doctest(1,0,0)
+
+import Distribution.Extra.Doctest ( defaultMainAutoconfWithDoctests )
+main :: IO ()
+main = defaultMainAutoconfWithDoctests "doctests"
+
+#else
+
+#ifdef MIN_VERSION_Cabal
+-- If the macro is defined, we have new cabal-install,
+-- but for some reason we don't have cabal-doctest in package-db
+--
+-- Probably we are running cabal sdist, when otherwise using new-build
+-- workflow
+#warning You are configuring this package without cabal-doctest installed. \
+         The doctests test-suite will not work as a result. \
+         To fix this, install cabal-doctest before configuring.
+#endif
 
 import Distribution.Simple
 
 main :: IO ()
-main = defaultMainWithHooks autoconfUserHooks
+main = defaultMain
+
+#endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,17 @@ environment:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
   matrix:
     - GHCVER: "7.8.4.1"
+      DOCTEST: "NO"
     - GHCVER: "7.10.3.2"
+      DOCTEST: "NO"
     - GHCVER: "8.0.2"
+      DOCTEST: "YES"
     - GHCVER: "8.2.2"
-    - GHCVER: "8.4.3"
+      DOCTEST: "YES"
+    - GHCVER: "8.4.4"
+      DOCTEST: "YES"
+    - GHCVER: "8.6.3"
+      DOCTEST: "YES"
 
 platform:
 #  - x86 # We may want to test x86 as well, but it would double the 23min build time.
@@ -26,6 +33,8 @@ install:
  - "cabal --version"
  - "ghc --version"
  - "cabal %CABOPTS% update -vverbose+nowrap"
+ - "cabal %CABOPTS% install hspec-discover"
+ - "cabal %CABOPTS% install cabal-doctest"
 
 build: off
 deploy: off
@@ -35,7 +44,6 @@ test_script:
  - "cabal %CABOPTS% new-build -j1 -vnormal+nowrap --dry all"
  - ps: Push-AppveyorArtifact dist-newstyle\cache\plan.json
  - "cabal %CABOPTS% new-build -j1 -vnormal+nowrap all"
- - "cabal %CABOPTS% install hspec-discover"
- # disable doctest because it's currently broken.
- - "cabal %CABOPTS% new-test  -j1 -vnormal+nowrap network:test:spec"
+ - IF "%DOCTEST%"=="YES" (set TESTSUITE=all) ELSE (set TESTSUITE=network:test:spec)
+ - "cabal %CABOPTS% new-test  -j1 -vnormal+nowrap %TESTSUITE%"
  - ps: ls network*.log -recurse | %{ Push-AppveyorArtifact $_}

--- a/network.cabal
+++ b/network.cabal
@@ -28,7 +28,7 @@ description:
   > library
   >   build-depends: network-uri-flag
 category:       Network
-build-type:     Configure
+build-type:     Custom
 cabal-version:  >=1.10
 extra-tmp-files:
   config.log config.status autom4te.cache network.buildinfo
@@ -49,6 +49,9 @@ tested-with:   GHC == 7.8.4
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.2
+
+custom-setup
+  setup-depends:        base, Cabal, cabal-doctest >=1.0.6 && <1.1
 
 library
   default-language: Haskell2010
@@ -123,7 +126,7 @@ test-suite spec
     network,
     hspec
 
-test-suite doctest
+test-suite doctests
   default-language: Haskell2010
   hs-source-dirs: tests
   main-is: doctests.hs
@@ -131,7 +134,8 @@ test-suite doctest
 
   build-depends:
     base >= 4.7 && < 5,
-    doctest >= 0.10.1
+    doctest >= 0.10.1,
+    network
 
   ghc-options: -Wall
 

--- a/network.cabal
+++ b/network.cabal
@@ -110,6 +110,8 @@ library
       Network.Socket.ByteString.Lazy.Windows
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
     extra-libraries: ws2_32
+    -- See https://github.com/haskell/network/pull/362
+    cpp-options: -D_WIN32_WINNT=0x0600
 
 test-suite spec
   default-language: Haskell2010

--- a/network.cabal
+++ b/network.cabal
@@ -89,6 +89,7 @@ library
   install-includes: HsNet.h HsNetDef.h
   c-sources: cbits/HsNet.c
   ghc-options: -Wall -fwarn-tabs
+  build-tools: hsc2hs
 
 
   -- Add some platform specific stuff

--- a/network.cabal
+++ b/network.cabal
@@ -111,7 +111,8 @@ library
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
     extra-libraries: ws2_32
     -- See https://github.com/haskell/network/pull/362
-    cpp-options: -D_WIN32_WINNT=0x0600
+    if impl(ghc >= 7.10)
+      cpp-options: -D_WIN32_WINNT=0x0600
 
 test-suite spec
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.18
+resolver: lts-12.24
 packages:
 - '.'
 nix:

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,21 +1,15 @@
-import Test.DocTest
+module Main where
+
+import Build_doctests (flags, pkgs, module_sources)
+import Data.Foldable (traverse_)
+import Data.List (isSuffixOf, isPrefixOf)
+import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest [
-    "-i"
-  , "-idist/build"
-  , "-i."
-  , "-idist/build/autogen"
-  , "-Idist/build/autogen"
-  , "-Idist/build"
-  , "-Iinclude"
-  , "-Idist/build/include"
-  , "-optP-include"
-  , "-optPdist/build/autogen/cabal_macros.h"
-  , "-DCALLCONV=ccall"
-  , "-XCPP"
-  , "-XDeriveDataTypeable"
-  , "-package-db dist/package.conf.inplace"
-  , "-package network"
-  , "Network"
-  ]
+main = do
+    traverse_ putStrLn args
+    doctest args
+  where
+    builddir = filter ("build" `isSuffixOf`) $ filter ("-i" `isPrefixOf`) flags
+    addinc path = "-I" ++ drop 2 path ++ "/include"
+    args = map addinc builddir ++ flags ++ pkgs ++ module_sources


### PR DESCRIPTION
`doctest` was disabled since `cabal` and `stack` cannot be share the build directory. `cabal-doctest` fills this gap. This PR enables doctests on CIs.

@Mistuke Only GHC 7.10.3 on appvoyer fails. I guess it's due to `hsc2hs` since I have experienced "hsc2hs not found" for GHC 7.10.3 on Travis CI. You can see the workaround in `.travis.yml` in this PR. Would you give a look?