### PR TITLE
Fix error handling in connect

### DIFF
--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -160,7 +160,7 @@ connectLoop s p_sa sz = loop
        fd <- fromIntegral <$> fdSocket s
        threadWaitWrite fd
        err <- getSocketOption s SoError
-       when (err == -1) $ throwSocketErrorCode errLoc (fromIntegral err)
+       when (err /= 0) $ throwSocketErrorCode errLoc (fromIntegral err)
 #endif
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
`getocketOption s SoError` returns errno, not 0/-1 flag. For example, for "Connection Refused" it returns 111, but this error gets swallowed by the handler code.