### PR TITLE
Use build-type Simple

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,0 @@
-module Main (main) where
-
-import Distribution.Simple
-
-main :: IO ()
-main = defaultMainWithHooks autoconfUserHooks

--- a/network.cabal
+++ b/network.cabal
@@ -29,7 +29,7 @@ description:
   > library
   >   build-depends: network-uri-flag
 category:       Network
-build-type:     Configure
+build-type:     Simple
 extra-tmp-files:
   config.log config.status autom4te.cache network.buildinfo
   include/HsNetworkConfig.h


### PR DESCRIPTION
`network` moved away from its more complex Setup.hs to a default build.
However the `build-type` setting was never set to `Simple`. This leads
to build failures with `stack` if the `Setup.hs` file is not present.
With `build-type: Simple` everything works as expected.