### PR TITLE
Set correct sockaddr length for abstract addresses

### DIFF
--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -941,7 +941,10 @@ type CSaFamily = (#type sa_family_t)
 -- in that the value of the argument /is/ used.
 sizeOfSockAddr :: SockAddr -> Int
 #if defined(DOMAIN_SOCKET_SUPPORT)
-sizeOfSockAddr SockAddrUnix{}  = #const sizeof(struct sockaddr_un)
+sizeOfSockAddr (SockAddrUnix path) =
+    case path of
+        '\0':_ -> (#const sizeof(sa_family_t)) + length path
+        _      -> #const sizeof(struct sockaddr_un)
 #else
 sizeOfSockAddr SockAddrUnix{}  = error "sizeOfSockAddr: not supported"
 #endif


### PR DESCRIPTION
There are three types of unix sockets [in Linux]: pathname, unnamed and abstract, see unix(7) for details. It is okay to use long sockaddr len with the pathname, which is null-terminated, and unnamed, which has no name.

But sun_path in the abstract sockaddr is effectively a blob, and sockaddr length must be set correctly. Otherwise, the connection fails.

Good strace:
```
9963  connect(4, {sa_family=AF_UNIX, sun_path=@"/tmp/dbus-fGvREc7jlQ"}, 23 <unfinished ...>
```

Bad strace:
```
connect(4, {sa_family=AF_UNIX, sun_path=@"/tmp/dbus-fLBigq6VT1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"}, 110 <unfinished ...>
```