### PR TITLE
Add coverage for ipv6 handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,13 @@ install:
  - cabal v2-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
  - cabal v2-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
 
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
+
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -33,6 +33,21 @@ spec = do
                 { clientSetup = readMVar portVar >>= connect'
                 }
 
+    describe "bind" $ do
+        let hints = defaultHints
+                { addrFlags = [AI_PASSIVE]
+                , addrSocketType = Stream
+                }
+        it "successfully binds to an ipv6 socket" $ do
+            addr:_ <- getAddrInfo (Just hints) (Just serverAddr6) Nothing
+            sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+            bind sock $ addrAddress addr
+
+        it "fails to bind to unknown ipv6 socket" $ do
+            addr:_ <- getAddrInfo (Just hints) (Just "::6") Nothing
+            sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+            bind sock (addrAddress addr) `shouldThrow` anyIOException
+
     describe "UserTimeout" $ do
         it "can be set" $ do
             when (isSupportedSocketOption UserTimeout) $ do

--- a/tests/Network/Test/Common.hs
+++ b/tests/Network/Test/Common.hs
@@ -18,6 +18,7 @@ module Network.Test.Common
   , udpTest
   -- * Common constants
   , serverAddr
+  , serverAddr6
   , unixAddr
   , testMsg
   , lazyTestMsg
@@ -37,6 +38,9 @@ import Test.Hspec
 
 serverAddr :: String
 serverAddr = "127.0.0.1"
+
+serverAddr6 :: String
+serverAddr6 = "::1"
 
 testMsg :: ByteString
 testMsg = "This is a test message."


### PR DESCRIPTION
`network`'s test suite does not exercise any ipv6 codepaths. Binding to
`::1` gives these paths some minimal coverage to avoid egregious
regressions.