### PR TITLE
Remove unix dependency

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -95,8 +95,6 @@ library
       Network.Socket.ByteString.IOVec
       Network.Socket.ByteString.Lazy.Posix
       Network.Socket.ByteString.MsgHdr
-    build-depends:
-      unix >= 2
     c-sources: cbits/ancilData.c
 
   if os(solaris)


### PR DESCRIPTION
The `weeder` tool identified `unix` as an unnecessary dependency. This
is a relic from before the bsd module was moved to its own package.