### PR TITLE
Add loopback tests for if index

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -104,7 +104,7 @@ library
     other-modules:
       Network.Socket.ByteString.Lazy.Windows
     c-sources: cbits/initWinSock.c, cbits/winSockErr.c, cbits/asyncAccept.c
-    extra-libraries: ws2_32
+    extra-libraries: ws2_32, iphlpapi
     -- See https://github.com/haskell/network/pull/362
     if impl(ghc >= 7.10)
       cpp-options: -D_WIN32_WINNT=0x0600

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -82,6 +82,8 @@ spec = do
     describe "ifNameToIndex" $ do
         it "converts a name to an index" $
             ifNameToIndex "lo" `shouldReturn` Just 1
+
+    describe "ifIndexToName" $ do
         it "converts an index to a name" $
             ifIndexToName 1 `shouldReturn` Just "lo"
 

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -79,13 +79,19 @@ spec = do
             let hints = defaultHints { addrFlags = [AI_NUMERICSERV] }
             void $ getAddrInfo (Just hints) (Just "localhost") Nothing
 
+#if defined(mingw32_HOST_OS)
+    let lpdevname = "loopback_0"
+#else
+    let lpdevname = "lo"
+#endif
+
     describe "ifNameToIndex" $ do
         it "converts a name to an index" $
-            ifNameToIndex "lo" `shouldReturn` Just 1
+            ifNameToIndex lpdevname `shouldReturn` Just 1
 
     describe "ifIndexToName" $ do
         it "converts an index to a name" $
-            ifIndexToName 1 `shouldReturn` Just "lo"
+            ifIndexToName 1 `shouldReturn` Just lpdevname
 
 
     when isUnixDomainSocketAvailable $ do

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -79,6 +79,13 @@ spec = do
             let hints = defaultHints { addrFlags = [AI_NUMERICSERV] }
             void $ getAddrInfo (Just hints) (Just "localhost") Nothing
 
+    describe "ifNameToIndex" $ do
+        it "converts a name to an index" $
+            ifNameToIndex "lo" `shouldReturn` Just 1
+        it "converts an index to a name" $
+            ifIndexToName 1 `shouldReturn` Just "lo"
+
+
     when isUnixDomainSocketAvailable $ do
         context "unix sockets" $ do
             it "basic unix sockets end-to-end" $ do


### PR DESCRIPTION
I've added a tests for `ifIndexToName` and `ifNameToIndex`. As expected these are passing on Linux and failing on Windows.

We either need to disable these functions for Windows or handle them in that environment. @Mistuke do you have any recommendations?

Related Issues:
https://github.com/haskell/network/issues/390
https://github.com/haskell/haskell-platform/issues/318#issuecomment-470370214
https://github.com/haskell/network/issues/361