### PR TITLE
Tidy AppVeyor script a bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,47 +1,69 @@
 version: "{build}"
 clone_folder: "c:\\network"
 
+
+# Do not build feature branch with open Pull Requests
+# prevents PR double builds as branch
+skip_branch_with_pr: true
+
 environment:
   global:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http"
+    DOCTEST: YES
   matrix:
-    - GHCVER: "7.8.4.1"
-      DOCTEST: "NO"
-    - GHCVER: "7.10.3.2"
-      DOCTEST: "NO"
-    - GHCVER: "8.0.2"
-      DOCTEST: "YES"
-    - GHCVER: "8.2.2"
-      DOCTEST: "YES"
-    - GHCVER: "8.4.4"
-      DOCTEST: "YES"
-    - GHCVER: "8.6.3"
-      DOCTEST: "YES"
+    - GHCVER: 7.8.4.1
+    - GHCVER: 7.10.3.2
+    - GHCVER: 8.0.2
+    - GHCVER: 8.2.2
+    - GHCVER: 8.4.4
+    - GHCVER: 8.6.3
 
 platform:
 #  - x86 # We may want to test x86 as well, but it would double the 23min build time.
   - x64
 
+for:
+  -
+    matrix:
+      only:
+        - platform: x86
+    environment:
+      global:
+        CHOCOPTS: --forcex86
+  -
+    matrix:
+      only:
+        - GHCVER: 7.8.4.1
+        - GHCVER: 7.10.3.2
+    environment:
+      global:
+        DOCTEST: NO
+
+
 cache:
  - "C:\\SR"
 
 install:
- - "choco install -y cabal"
- - "choco install -y ghc --version %GHCVER%"
- - "refreshenv"
- - "set PATH=C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin;C:\\ghc\\ghc-%GHCVER%\\bin;%PATH%"
- - "cabal --version"
- - "ghc --version"
- - "cabal %CABOPTS% update -vverbose+nowrap"
+ - choco install -y cabal %CHOCOPTS%
+ - choco install -y ghc --version %GHCVER% %CHOCOPTS%
+ - refreshenv
+ - set PATH=C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin;C:\\ghc\\ghc-%GHCVER%\\bin;%PATH%
 
-build: off
+before_build:
+ - cabal --version
+ - ghc --version
+ - cabal %CABOPTS% new-update -vverbose+nowrap
+ - IF EXIST configure.ac bash -c "autoreconf -i"
+
 deploy: off
 
-test_script:
+build_script:
  - IF EXIST configure.ac bash -c "autoreconf -i"
- - "cabal %CABOPTS% v2-build -j1 -vnormal+nowrap --dry all"
+ - cabal %CABOPTS% v2-build -j1 -vnormal+nowrap --dry all
  - ps: Push-AppveyorArtifact dist-newstyle\cache\plan.json
- - "cabal %CABOPTS% v2-build -j1 -vnormal+nowrap all"
+ - cabal %CABOPTS% v2-build -j1 -vnormal+nowrap all
+
+test_script:
  - IF "%DOCTEST%"=="YES" bash enable_doctest.sh
- - "cabal %CABOPTS% v2-test  -j1 -vnormal+nowrap all"
+ - cabal %CABOPTS% v2-test  -j1 -vnormal+nowrap all
  - ps: ls network*.log -recurse | %{ Push-AppveyorArtifact $_}


### PR DESCRIPTION
- Remove the unneeded quotes around commands
- Simplify matrix configuration
- Add x86 support configuration in case we wanted to add it in the future.
- Prevent PRs from being built twice, once as a PR and another as branch
- Split up tasks during build so appveyor categorizes the stages