### PR TITLE
Fixing unix socket on 2.8

### DIFF
--- a/Network/Socket.hsc
+++ b/Network/Socket.hsc
@@ -641,6 +641,7 @@ accept sock@(MkSocket s family stype protocol status) = do
    else do
      let sz = sizeOfSockAddrByFamily family
      allocaBytes sz $ \ sockaddr -> do
+     zeroMemory sockaddr $ fromIntegral sz
 #if defined(mingw32_HOST_OS)
      new_sock <-
         if threaded

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -112,10 +112,15 @@ spec = do
         it "can end-to-end with an abstract socket" $ do
             when isUnixDomainSocketAvailable $ do
                 let
-                    abstractAddress = toEnum 0:"/haskell/network/long-abstract"
+                    abstractAddress = toEnum 0:"/haskell/network/abstract"
                     clientAct sock = send sock testMsg
                     server (sock, addr) = do
                       recv sock 1024 `shouldReturn` testMsg
                       addr `shouldBe` (SockAddrUnix "")
                 unixTestWith abstractAddress (const $ return ()) clientAct server
+        it "safely throws an exception" $ do
+            when isUnixDomainSocketAvailable $ do
+                let abstractAddress = toEnum 0:"/haskell/network/abstract-longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"
+                sock <- socket AF_UNIX Stream defaultProtocol
+                bind sock (SockAddrUnix abstractAddress) `shouldThrow` anyErrorCall
 #endif


### PR DESCRIPTION
- 1st commit: imports test case for Unix domain by Evan  (an error happens)
- 2nd commit: fixing sockaddr returned from `accept` (#306) (the error is fixed)
- 3nd commit: adding an error test case for abstract Unix socket (another error happens)
- 4th commit: fixing Unix domain support on 2.8 like 3.x (#382) (the error is fixed)