### PR TITLE
getAddrInfo: raise exception if no AddrInfo returned

### DIFF
--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -282,7 +282,11 @@ getAddrInfo hints node service = alloc getaddrinfo
             ptr_addrs <- peek ptr_ptr_addrs
             ais       <- followAddrInfo ptr_addrs
             c_freeaddrinfo ptr_addrs
-            return ais
+            -- POSIX requires that getaddrinfo(3) returns at least one addrinfo.
+            -- See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html
+            case ais of
+              [] -> ioError $ mkIOError NoSuchThing message Nothing Nothing
+              _ -> pure ais
           else do
             err <- gai_strerror ret
             ioError $ ioeSetErrorString


### PR DESCRIPTION
Closes #407.

POSIX[1] requires getaddrinfo(3) to return at least one addrinfo:

> Upon successful return of getaddrinfo(), the location to which res
> points shall refer to a linked list of addrinfo structures, each of
> which shall specify a socket address and information for use in
> creating a socket with which to use that socket address. The list
> shall include at least one addrinfo structure.

This behaviour is also specified by the manpages for Linux[2],
OpenBSD[3], FreeBSD[4], NetBSD[5] and macOS[6], and most example code
just calls `head` (or equivalent) on the returned list anyway.

It would have been nice to return `NonEmpty` here, but that was vetoed
for backwards-compatibility reasons.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html
[2]: https://linux.die.net/man/3/getaddrinfo
[3]: https://man.openbsd.org/getaddrinfo.3
[4]: http://nixdoc.net/man-pages/FreeBSD/man4/man3/getaddrinfo.3.html
[5]: http://nixdoc.net/man-pages/NetBSD/man3/getaddrinfo.3.html
[6]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/getaddrinfo.3.html