### PR TITLE
Provide documentation for extended packages

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -15,7 +15,11 @@ description:
   * hookup
   * network-simple
   .
-  === Related Packages
+  === Extended Packages
+  @network@ seeks to provide a cross-platform core for networking. As such some
+  APIs live in extended libraries. Packages in the @network@ ecosystem are
+  often prefixed with @network-@.
+  .
   ==== @network-bsd@
   In @network-3.0.0.0@ the @Network.BSD@ module was split off into its own
   package, @network-bsd-3.0.0.0@.


### PR DESCRIPTION
`network` does not seek to be an end-all-be-all for networking needs.
Instead it seeks to be a cross-platform core. Other packages can be used
to extend this core for platform specific APIs. This commit provides
documentation of this fact for future users.

Closes #381 