### PR TITLE
Don't catch SomeException

### DIFF
--- a/Network/Socket/Buffer.hs
+++ b/Network/Socket/Buffer.hs
@@ -9,10 +9,9 @@ module Network.Socket.Buffer (
   , recvBuf
   ) where
 
-import qualified Control.Exception as E
 import Foreign.Marshal.Alloc (alloca)
 import GHC.IO.Exception (IOErrorType(InvalidArgument))
-import System.IO.Error (mkIOError, ioeSetErrorString)
+import System.IO.Error (mkIOError, ioeSetErrorString, catchIOError)
 
 #if defined(mingw32_HOST_OS)
 import GHC.IO.FD (FD(..), readRawBufferPtr, writeRawBufferPtr)
@@ -98,7 +97,7 @@ recvBufFrom s ptr nbytes
             len <- throwSocketErrorWaitRead s "Network.Socket.recvBufFrom" $
                      c_recvfrom fd ptr cnbytes flags ptr_sa ptr_len
             sockaddr <- peekSocketAddress ptr_sa
-                `E.catch` \(E.SomeException _) -> getPeerName s
+                `catchIOError` \_ -> getPeerName s
             return (fromIntegral len, sockaddr)
 
 -- | Receive data from the socket.  The socket must be in a connected

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 #include "HsNetDef.h"
 
@@ -7,6 +6,9 @@ module Network.Socket.Syscall where
 
 import Foreign.Marshal.Utils (with)
 import qualified Control.Exception as E
+# if defined(mingw32_HOST_OS)
+import System.IO.Error (catchIOError)
+#endif
 
 #if defined(mingw32_HOST_OS)
 import Foreign (FunPtr)
@@ -103,7 +105,7 @@ socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
 # if defined(mingw32_HOST_OS)
       -- The IPv6Only option is only supported on Windows Vista and later,
       -- so trying to change it might throw an error.
-      E.catch (setSocketOption s IPv6Only 0) $ (\(_ :: E.IOException) -> return ())
+      setSocketOption s IPv6Only 0 `catchIOError` \_ -> return ()
 # elif defined(__OpenBSD__)
       -- don't change IPv6Only
       return ()


### PR DESCRIPTION
Exception handling was overly broad in some places. We only need to
catch `IOException`.

`Control.Exception` can be used to catch `IOException`, which requires
`ScopedTypeVariables` or we can use `catchIOError`. This commit chooses
`catchIOError` for its simplicity.

Closes #376 