### PR TITLE
implementing gracefulClose.

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -122,6 +122,7 @@ module Network.Socket
     -- ** Closing
     , close
     , close'
+    , gracefulClose
     , shutdown
     , ShutdownCmd(..)
 

--- a/Network/Socket/Buffer.hsc
+++ b/Network/Socket/Buffer.hsc
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 
-#include "HsNetDef.h"
+##include "HsNetDef.h"
+#if defined(mingw32_HOST_OS)
+#  include "windows.h"
+#endif
 
 module Network.Socket.Buffer (
     sendBufTo
@@ -10,7 +13,9 @@ module Network.Socket.Buffer (
   , recvBufNoWait
   ) where
 
+#if !defined(mingw32_HOST_OS)
 import Foreign.C.Error (getErrno, eAGAIN, eWOULDBLOCK)
+#endif
 import Foreign.Marshal.Alloc (alloca)
 import GHC.IO.Exception (IOErrorType(InvalidArgument))
 import System.IO.Error (mkIOError, ioeSetErrorString, catchIOError)
@@ -138,6 +143,26 @@ recvBuf s ptr nbytes
 --   -2 is returned in other error cases.
 recvBufNoWait :: Socket -> Ptr Word8 -> Int -> IO Int
 recvBufNoWait s ptr nbytes = withFdSocket s $ \fd -> do
+#if defined(mingw32_HOST_OS)
+    alloca $ \ptr_bytes -> do
+      avail <- c_ioctlsocket fd #{const FIONREAD} ptr_bytes
+      r <- if avail > 0 then
+               c_recv fd (castPtr ptr) (fromIntegral nbytes) 0{-flags-}
+           else if avail == 0 then
+               -- Socket would block, could also mean socket is closed but
+               -- can't distinguish
+               return (-1)
+           else return avail
+      if r >= 0 then
+        return $ fromIntegral r
+        else do
+          err <- c_WSAGetLastError
+          if err == #{const WSAEWOULDBLOCK}
+             || err == #{const WSAEINPROGRESS} then
+              return (-1)
+            else
+              return (-2)
+#else
     r <- c_recv fd (castPtr ptr) (fromIntegral nbytes) 0{-flags-}
     if r >= 0 then
         return $ fromIntegral r
@@ -147,6 +172,7 @@ recvBufNoWait s ptr nbytes = withFdSocket s $ \fd -> do
             return (-1)
           else
             return (-2)
+#endif
 
 mkInvalidRecvArgError :: String -> IOError
 mkInvalidRecvArgError loc = ioeSetErrorString (mkIOError
@@ -156,9 +182,14 @@ mkInvalidRecvArgError loc = ioeSetErrorString (mkIOError
 #if !defined(mingw32_HOST_OS)
 foreign import ccall unsafe "send"
   c_send :: CInt -> Ptr a -> CSize -> CInt -> IO CInt
+#else
+foreign import CALLCONV SAFE_ON_WIN "ioctlsocket"
+  c_ioctlsocket :: CInt -> CLong -> Ptr CULong -> IO CInt
+foreign import CALLCONV SAFE_ON_WIN "WSAGetLastError"
+  c_WSAGetLastError :: IO CInt
+#endif
 foreign import ccall unsafe "recv"
   c_recv :: CInt -> Ptr CChar -> CSize -> CInt -> IO CInt
-#endif
 foreign import CALLCONV SAFE_ON_WIN "sendto"
   c_sendto :: CInt -> Ptr a -> CSize -> CInt -> Ptr sa -> CInt -> IO CInt
 foreign import CALLCONV SAFE_ON_WIN "recvfrom"

--- a/Network/Socket/Buffer.hsc
+++ b/Network/Socket/Buffer.hsc
@@ -145,15 +145,16 @@ recvBufNoWait :: Socket -> Ptr Word8 -> Int -> IO Int
 recvBufNoWait s ptr nbytes = withFdSocket s $ \fd -> do
 #if defined(mingw32_HOST_OS)
     alloca $ \ptr_bytes -> do
-      avail <- c_ioctlsocket fd #{const FIONREAD} ptr_bytes
-      r <- if avail > 0 then
+      res <- c_ioctlsocket fd #{const FIONREAD} ptr_bytes
+      avail <- peek ptr_bytes
+      r <- if res == #{const NO_ERROR} then
                c_recv fd (castPtr ptr) (fromIntegral nbytes) 0{-flags-}
            else if avail == 0 then
                -- Socket would block, could also mean socket is closed but
                -- can't distinguish
                return (-1)
-           else return avail
-      if r >= 0 then
+           else return $ fromIntegral avail
+      if r >= 0 || avail == 0 then
         return $ fromIntegral r
         else do
           err <- c_WSAGetLastError

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -59,7 +59,7 @@ data Wait = MoreData | TimeoutTripped
 --
 --   Since: 3.1.1.0
 gracefulClose :: Socket -> Int -> IO ()
-gracefulClose s tmout = (sendRecvFIN `E.finally` close s) `E.catch` ignore
+gracefulClose s tmout = sendRecvFIN `E.finally` close s
   where
     sendRecvFIN = do
         -- Sending TCP FIN.
@@ -119,7 +119,3 @@ gracefulClose s tmout = (sendRecvFIN `E.finally` close s) `E.catch` ignore
     -- Don't use 4092 here. The GHC runtime takes the global lock
     -- if the length is over 3276 bytes in 32bit or 3272 bytes in 64bit.
     bufSize = 1024
-    -- shutdown sometime returns ENOTCONN.
-    -- Probably, we don't want to log this error.
-    ignore :: E.IOException -> IO ()
-    ignore _e = return ()

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -9,9 +9,11 @@ module Network.Socket.Shutdown (
   , gracefulClose
   ) where
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (putMVar, takeMVar, newEmptyMVar)
 import qualified Control.Exception as E
 import Foreign.Marshal.Alloc (mallocBytes, free)
+import qualified GHC.Event as Ev
+import System.Posix.Types (Fd(..))
 
 import Network.Socket.Buffer
 import Network.Socket.Imports
@@ -41,6 +43,7 @@ shutdown s stype = void $ withFdSocket s $ \fd ->
 foreign import CALLCONV unsafe "shutdown"
   c_shutdown :: CInt -> CInt -> IO CInt
 
+data Wait = MoreData | TimeoutTripped
 
 -- | Closing a socket gracefully.
 --   This sends TCP FIN and check if TCP FIN is received from the peer.
@@ -49,31 +52,42 @@ foreign import CALLCONV unsafe "shutdown"
 --
 --   Since: 3.1.1.0
 gracefulClose :: Socket -> Int -> IO ()
-gracefulClose s tm = (sendRecvFIN `E.finally` close s) `E.catch` ignore
+gracefulClose s tmout = (sendRecvFIN `E.finally` close s) `E.catch` ignore
   where
     sendRecvFIN = do
         -- Sending TCP FIN.
         shutdown s ShutdownSend
         -- Waiting TCP FIN.
         E.bracket (mallocBytes bufSize) free recvEOF
-    recvEOF buf = loop 0
-      where
-        loop delay = do
-            -- We don't check the (positive) length.
-            -- In normal case, it's 0. That is, only FIN is received.
-            -- In error cases, data is available. But there is no
-            -- application which can read it. So, let's stop receiving
-            -- to prevent attacks.
-            r <- recvBufNoWait s buf bufSize
-            let delay' = delay + clock
-            when (r == -1 && delay' < tm) $ do
-                threadDelay (clock * 1000)
-                loop delay'
+    recvEOF buf = do
+        Just evmgr <- Ev.getSystemEventManager
+        tmmgr <- Ev.getSystemTimerManager
+        mvar <- newEmptyMVar
+        E.bracket (setup evmgr tmmgr mvar) (teardown evmgr tmmgr) $ \_ -> do
+            wait <- takeMVar mvar
+            case wait of
+              TimeoutTripped -> return ()
+              -- We don't check the (positive) length.
+              -- In normal case, it's 0. That is, only FIN is received.
+              -- In error cases, data is available. But there is no
+              -- application which can read it. So, let's stop receiving
+              -- to prevent attacks.
+              MoreData       -> void $ recvBufNoWait s buf bufSize
+    setup evmgr tmmgr mvar = do
+        -- millisecond to microsecond
+        key1 <- Ev.registerTimeout tmmgr (tmout * 1000) $
+            putMVar mvar TimeoutTripped
+        key2 <- withFdSocket s $ \fd' -> do
+            let callback _ _ = putMVar mvar MoreData
+                fd = Fd fd'
+            Ev.registerFd evmgr callback fd Ev.evtRead Ev.OneShot
+        return (key1, key2)
+    teardown evmgr tmmgr (key1,key2) = do
+        Ev.unregisterTimeout tmmgr key1
+        Ev.unregisterFd evmgr key2
     -- Don't use 4092 here. The GHC runtime takes the global lock
     -- if the length is over 3276 bytes in 32bit or 3272 bytes in 64bit.
     bufSize = 1024
-    -- milliseconds. Taken from BSD fast clock value.
-    clock = 200
     -- shutdown sometime returns ENOTCONN.
     -- Probably, we don't want to log this error.
     ignore :: E.IOException -> IO ()

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -82,7 +82,11 @@ gracefulClose s tmout = (sendRecvFIN `E.finally` close s) `E.catch` ignore
         key2 <- withFdSocket s $ \fd' -> do
             let callback _ _ = putMVar mvar MoreData
                 fd = Fd fd'
+#if __GLASGOW_HASKELL__ < 709
+            Ev.registerFd evmgr callback fd Ev.evtRead
+#else
             Ev.registerFd evmgr callback fd Ev.evtRead Ev.OneShot
+#endif
         return (key1, key2)
     unregister evmgr tmmgr (key1,key2) = do
         Ev.unregisterTimeout tmmgr key1

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -76,4 +76,5 @@ gracefulClose s tm = (sendRecvFIN `E.finally` close s) `E.catch` ignore
     clock = 200
     -- shutdown sometime returns ENOTCONN.
     -- Probably, we don't want to log this error.
-    ignore (E.SomeException _e) = return ()
+    ignore :: E.IOException -> IO ()
+    ignore _e = return ()

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([Haskell network package],
-        [3.1.0.1],
+        [3.1.1.0],
         [libraries@haskell.org],
         [network])
 

--- a/network.cabal
+++ b/network.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.18
 name:           network
-version:        3.1.0.1
+version:        3.1.1.0
 license:        BSD3
 license-file:   LICENSE
 maintainer:     Kazu Yamamoto, Evan Borden

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -196,3 +196,16 @@ spec = do
                     cred1 <- getPeerCredential s
                     cred1 `shouldBe` (Nothing,Nothing,Nothing)
             -}
+
+    describe "gracefulClose" $ do
+        it "does not send TCP RST back" $ do
+            let server sock = do
+                    void $ recv sock 1024 -- receiving "GOAWAY"
+                    gracefulClose sock 3000
+                client sock = do
+                    sendAll sock "GOAWAY"
+                    threadDelay 10000
+                    sendAll sock "PING"
+                    threadDelay 10000
+                    void $ recv sock 1024
+            tcpTest client server


### PR DESCRIPTION
Suppose that we have an HTTP/2 server. When the server tries to close the connection, it sends a GOAWAY frame. And suppose that the server `close`s the socket immediately. TCP ACK regarding to GOAWAY may reach to the server after the socket is gone. In this case, TCP RST is sent from the server to the client. The client misunderstands that this communication failed.

To close sockets gracefully,  we should do:
- `shutdown(2) TX` to send TCP FIN
- `recv(2)` to check if TCP FIN has been arrived from the peer. This operation should be timed out.
- Both in normal and error cases, deallocate the socket with `close(2)`

To implement this, many things are missing in the `network` library:
- Actual implementation of `getSocketOption` and `setSocketOption` for `RecvTimeout`
- Setting sockets back to blocking. This is necessary because that both non-blocking sockets without timeout and blocking sockets with timeout return `EWOULDBLOCK`. 
- Receiving data from blocking sockets without triggering the IO manager.

This PR implements all above. To keep the signatures of `getSocketOption` and `setSocketOption`, I took the Windows way. That is, the argument is `Int` in milliseconds.
