### PR TITLE
Implement socket names, in particular reading a string description of them

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -139,6 +139,7 @@ module Network.Socket
     -- * Socket
     , Socket
     , socket
+    , socketFromName
     , withFdSocket
     , unsafeFdSocket
     , touchSocket
@@ -158,8 +159,14 @@ module Network.Socket
     -- ** Protocol number
     , ProtocolNumber
     , defaultProtocol
+    -- * Basic socket name type
+    , SockName(..)
+    , readSockName
+    , showSockName
+    , sockNameToAddr
     -- * Basic socket address type
     , SockAddr(..)
+    , sockAddrFamily
     , isSupportedSockAddr
     , getPeerName
     , getSocketName

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -68,7 +68,7 @@ import Network.Socket.Types
 -- >>> sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
 -- >>> Network.Socket.bind sock (addrAddress addr)
 -- >>> getSocketName sock
--- 127.0.0.1:5000
+-- SockAddrInet 5000 16777343
 socket :: Family         -- Family Name (usually AF_INET)
        -> SocketType     -- Socket Type (usually Stream)
        -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -981,7 +981,7 @@ type ScopeID = Word32
 data SockName
   = SockName !String !PortNumber
   | SockAddr !SockAddr
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Typeable, Read, Show)
 
 -- | Socket addresses.
 --  The existence of a constructor does not necessarily imply that
@@ -999,7 +999,7 @@ data SockAddr
   -- | The path must have fewer than 104 characters. All of these characters must have code points less than 256.
   | SockAddrUnix
         String           -- sun_path
-  deriving (Eq, Ord, Typeable)
+  deriving (Eq, Ord, Typeable, Read, Show)
 
 instance NFData SockAddr where
   rnf (SockAddrInet _ _) = ()

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -42,7 +42,9 @@ module Network.Socket.Types (
     , withNewSocketAddress
 
     -- * Socket address type
+    , SockName(..)
     , SockAddr(..)
+    , sockAddrFamily
     , isSupportedSockAddr
     , HostAddress
     , hostAddressToTuple
@@ -970,6 +972,17 @@ type FlowInfo = Word32
 -- | Scope identifier.
 type ScopeID = Word32
 
+-- | Socket names.
+--  A wrapper around socket addresses that also accommodates the
+--  popular usage of specifying them by name, e.g. "example.com:80".
+--  Note that we don't support service names here because they also
+--  imply a particular socket type, which is outside of the scope of
+--  what this data type represents.
+data SockName
+  = SockName !String !PortNumber
+  | SockAddr !SockAddr
+  deriving (Eq, Ord)
+
 -- | Socket addresses.
 --  The existence of a constructor does not necessarily imply that
 --  that socket address type is supported on your system: see
@@ -992,6 +1005,12 @@ instance NFData SockAddr where
   rnf (SockAddrInet _ _) = ()
   rnf (SockAddrInet6 _ _ _ _) = ()
   rnf (SockAddrUnix str) = rnf str
+
+sockAddrFamily :: SockAddr -> Family
+sockAddrFamily addr = case addr of
+  SockAddrInet _ _ -> AF_INET
+  SockAddrInet6 _ _ _ _ -> AF_INET6
+  SockAddrUnix _ -> AF_UNIX
 
 -- | Is the socket address type supported on this system?
 isSupportedSockAddr :: SockAddr -> Bool

--- a/network.cabal
+++ b/network.cabal
@@ -83,7 +83,8 @@ library
   build-depends:
     base >= 4.7 && < 5,
     bytestring == 0.10.*,
-    deepseq
+    deepseq,
+    directory
 
   include-dirs: include
   includes: HsNet.h HsNetDef.h


### PR DESCRIPTION
Useful for 3rd-party networking applications that might want to pass around
service specifiers without worrying whether these are IP addresses, DNS names,
or UNIX-domain socket paths.

Previously, there was no data type to encapsulate these options together. In
particular, getAddrInfo had to be used to resolve DNS names into a SockAddr
before calling connect/bind, but it could not deal with UNIX domain sockets.
The new function sockNameToAddr takes this role, transparently converting DNS
names and passing through non-DNS-names unaltered, so that it can be used
uniformly without worrying about the specific type of input name/address.

The last two commits fix some historical behavioural oddities to make the
general end-user experience more friendly.
