### PR TITLE
Update haddocks for some Network.ByteString modules

### DIFF
--- a/Network/Socket/ByteString.hs
+++ b/Network/Socket/ByteString.hs
@@ -7,13 +7,12 @@
 -- Stability   : stable
 -- Portability : portable
 --
--- This module provides access to the BSD /socket/ interface.  This
--- module is generally more efficient than the 'String' based network
--- functions in 'Network.Socket'.  For detailed documentation, consult
--- your favorite POSIX socket reference. All functions communicate
--- failures by converting the error number to 'System.IO.IOError'.
+-- This module provides access to the BSD /socket/ interface. For detailed
+-- documentation, consult your favorite POSIX socket reference. All functions
+-- communicate failures by converting the error number to an
+-- 'System.IO.Error.IOError'.
 --
--- This module is made to be imported with 'Network.Socket' like so:
+-- This module is made to be imported with "Network.Socket" like so:
 --
 -- > import Network.Socket
 -- > import Network.Socket.ByteString
@@ -86,4 +85,3 @@ sendAllTo = G.sendAllTo
 -- 'SockAddr' representing the address of the sending socket.
 recvFrom :: Socket -> Int -> IO (ByteString, SockAddr)
 recvFrom = G.recvFrom
-

--- a/Network/Socket/ByteString/IO.hsc
+++ b/Network/Socket/ByteString/IO.hsc
@@ -4,24 +4,13 @@
 #include "HsNet.h"
 
 -- |
--- Module      : Network.Socket.ByteString
+-- Module      : Network.Socket.ByteString.IO
 -- Copyright   : (c) Johan Tibell 2007-2010
 -- License     : BSD-style
 --
 -- Maintainer  : johan.tibell@gmail.com
 -- Stability   : stable
 -- Portability : portable
---
--- This module provides access to the BSD /socket/ interface.  This
--- module is generally more efficient than the 'String' based network
--- functions in 'Network.Socket'.  For detailed documentation, consult
--- your favorite POSIX socket reference. All functions communicate
--- failures by converting the error number to 'System.IO.IOError'.
---
--- This module is made to be imported with 'Network.Socket' like so:
---
--- > import Network.Socket hiding (send, sendTo, recv, recvFrom)
--- > import Network.Socket.ByteString
 --
 module Network.Socket.ByteString.IO
     (

--- a/Network/Socket/ByteString/Lazy.hs
+++ b/Network/Socket/ByteString/Lazy.hs
@@ -8,13 +8,12 @@
 -- Stability   : experimental
 -- Portability : POSIX, GHC
 --
--- This module provides access to the BSD /socket/ interface.  This
--- module is generally more efficient than the 'String' based network
--- functions in 'Network.Socket'.  For detailed documentation, consult
--- your favorite POSIX socket reference. All functions communicate
--- failures by converting the error number to 'System.IO.IOError'.
+-- This module provides access to the BSD /socket/ interface.  For detailed
+-- documentation, consult your favorite POSIX socket reference. All functions
+-- communicate failures by converting the error number to an
+-- 'System.IO.Error.IOError'.
 --
--- This module is made to be imported with 'Network.Socket' like so:
+-- This module is made to be imported with "Network.Socket" like so:
 --
 -- > import Network.Socket
 -- > import Network.Socket.ByteString.Lazy

--- a/Network/Socket/Internal.hs
+++ b/Network/Socket/Internal.hs
@@ -13,8 +13,8 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- A module containing semi-public 'Network.Socket' internals.
--- Modules which extend the 'Network.Socket' module will need to use
+-- A module containing semi-public "Network.Socket" internals.
+-- Modules which extend the "Network.Socket" module will need to use
 -- this module while ideally most users will be able to make do with
 -- the public interface.
 --


### PR DESCRIPTION
This patch

- Removes two occurrences of "String based network functions in Network.Socket" which AFAICT were removed in v3.0
- Fixes some hyperlinks in the haddocks
- Removes the old header for Network.Socket.ByteString.IO