### PR TITLE
Export byte order conversation functions

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -208,6 +208,12 @@ module Network.Socket
 
     -- * Special constants
     , maxListenQueue
+
+    -- * Byte order transformation
+    , ntohl
+    , htonl
+    , ntohs
+    , htons
     ) where
 
 import Network.Socket.Buffer hiding (sendBufTo, recvBufFrom)

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -66,6 +66,8 @@ module Network.Socket.Types (
     , zeroMemory
     , htonl
     , ntohl
+    , htons
+    , ntohs
     ) where
 
 import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef', mkWeakIORef)
@@ -899,14 +901,14 @@ instance Show PortNumber where
 instance Read PortNumber where
   readsPrec n = map (\(x,y) -> (fromIntegral (x :: Int), y)) . readsPrec n
 
+-- | Converts from network byte order to host byte order.
 foreign import CALLCONV unsafe "ntohs" ntohs :: Word16 -> Word16
+-- | Converts from host byte order to network byte order.
 foreign import CALLCONV unsafe "htons" htons :: Word16 -> Word16
 -- | Converts the from host byte order to network byte order.
 foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
 -- | Converts the from network byte order to host byte order.
 foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
-{-# DEPRECATED htonl "Use getAddrInfo instead" #-}
-{-# DEPRECATED ntohl "Use getAddrInfo instead" #-}
 
 instance Storable PortNumber where
    sizeOf    _ = sizeOf    (undefined :: Word16)


### PR DESCRIPTION
The byte order conversation functions

ntoh{l,s}
hton{l,s}

are sometimes very usable. In the unix package it is stated, that these
functions should be supported by the network package [1].

There are also packages, which depend on these functions to be provided by
network [2], so export them.

[1] https://github.com/haskell/unix/blob/master/System/Posix.hs#L108
[2] https://github.com/taffybar/status-notifier-item/blob/master/src/StatusNotifier/Util.hs