### PR TITLE
Change u_int32_t to uint32_t for more portable

### DIFF
--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -93,7 +93,7 @@ hsnet_inet_ntoa(
 #elif defined(HAVE_IN_ADDR_T)
              in_addr_t addr
 #elif defined(HAVE_INTTYPES_H)
-             u_int32_t addr
+             uint32_t addr
 #else
              unsigned long addr
 #endif


### PR DESCRIPTION
code update for #437 