### PR TITLE
Update Travis and Cabal GHC version lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ matrix:
     - compiler: "ghc-8.8.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.8.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-head"
+    - compiler: "ghc-8.10.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
-  allow_failures:
-    - compiler: "ghc-head"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.10.1], sources: [hvr-ghc]}}
+#  allow_failures:
+#    - compiler: "ghc-head"
 
 before_install:
  - HC=${CC}

--- a/network.cabal
+++ b/network.cabal
@@ -47,12 +47,12 @@ extra-source-files:
   cbits/winSockErr.c cbits/cmsg.c
 homepage:       https://github.com/haskell/network
 bug-reports:    https://github.com/haskell/network/issues
-tested-with:   GHC == 7.8.4
-             , GHC == 7.10.3
-             , GHC == 8.0.2
+tested-with:   GHC == 8.0.2
              , GHC == 8.2.2
              , GHC == 8.4.4
-             , GHC == 8.6.2
+             , GHC == 8.6.5
+             , GHC == 8.8.3
+             , GHC == 8.10.1
 
 library
   default-language: Haskell2010


### PR DESCRIPTION
- We're not testing 7.x, so drop those from the Cabal list
- Replace ghc-head (currently stuck at 8.7) with 8.10.1 and
  expect it to work.
- Add 8.10.1 to the Cabal file list.