### PR TITLE
Using Strict and StrictData by default

### DIFF
--- a/Network/Socket/ByteString/IO.hsc
+++ b/Network/Socket/ByteString/IO.hsc
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -283,9 +282,9 @@ withWSABuffromBS cs f = withBufSizs cs $ \bufsizs -> withWSABuf bufsizs f
 withBufSizs :: [ByteString] -> ([(Ptr Word8, Int)] -> IO a) -> IO a
 withBufSizs bss0 f = loop bss0 id
   where
-    loop []                    !build = f $ build []
-    loop (PS fptr off len:bss) !build = withForeignPtr fptr $ \ptr -> do
-        let !ptr' = ptr `plusPtr` off
+    loop []                    build = f $ build []
+    loop (PS fptr off len:bss) build = withForeignPtr fptr $ \ptr -> do
+        let ptr' = ptr `plusPtr` off
         loop bss (build . ((ptr',len) :))
 
 -- | Send data to the socket using sendmsg(2).

--- a/Network/Socket/ByteString/Lazy/Posix.hs
+++ b/Network/Socket/ByteString/Lazy/Posix.hs
@@ -38,7 +38,7 @@ send s lbs = do
             | k < maxNumBytes = unsafeUseAsCStringLen c $ \(ptr, len) -> do
                 poke q $ IOVec (castPtr ptr) (fromIntegral len)
                 loop cs
-                     (q `plusPtr` sizeOf (undefined :: IOVec))
+                     (q `plusPtr` sizeOf (IOVec nullPtr 0))
                      (k + fromIntegral len)
                      (niovs + 1)
             | otherwise = f niovs

--- a/Network/Socket/ByteString/Lazy/Posix.hs
+++ b/Network/Socket/ByteString/Lazy/Posix.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Socket.ByteString.Lazy.Posix (
@@ -34,7 +33,7 @@ send s lbs = do
   where
     withPokes ss p f = loop ss p 0 0
       where
-        loop (c:cs) q k !niovs
+        loop (c:cs) q k niovs
             | k < maxNumBytes = unsafeUseAsCStringLen c $ \(ptr, len) -> do
                 poke q $ IOVec (castPtr ptr) (fromIntegral len)
                 loop cs

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -109,8 +109,8 @@ data AddrInfo = AddrInfo {
   } deriving (Eq, Show, Typeable)
 
 instance Storable AddrInfo where
-    sizeOf    _ = #const sizeof(struct addrinfo)
-    alignment _ = alignment (undefined :: CInt)
+    sizeOf    ~_ = #const sizeof(struct addrinfo)
+    alignment ~_ = alignment (0 :: CInt)
 
     peek p = do
         ai_flags <- (#peek struct addrinfo, ai_flags) p
@@ -200,8 +200,8 @@ defaultHints = AddrInfo {
   , addrFamily     = AF_UNSPEC
   , addrSocketType = NoSocketType
   , addrProtocol   = defaultProtocol
-  , addrAddress    = undefined
-  , addrCanonName  = undefined
+  , addrAddress    = SockAddrInet 0 0
+  , addrCanonName  = Nothing
   }
 
 -- | Shows the fields of 'defaultHints', without inspecting the by-default undefined fields 'addrAddress' and 'addrCanonName'.

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -181,9 +181,7 @@ niFlagMapping = [(NI_DGRAM, #const NI_DGRAM),
                  (NI_NUMERICHOST, #const NI_NUMERICHOST),
                  (NI_NUMERICSERV, #const NI_NUMERICSERV)]
 
--- | Default hints for address lookup with 'getAddrInfo'.  The values
--- of the 'addrAddress' and 'addrCanonName' fields are 'undefined',
--- and are never inspected by 'getAddrInfo'.
+-- | Default hints for address lookup with 'getAddrInfo'.
 --
 -- >>> addrFlags defaultHints
 -- []
@@ -203,25 +201,6 @@ defaultHints = AddrInfo {
   , addrAddress    = SockAddrInet 0 0
   , addrCanonName  = Nothing
   }
-
--- | Shows the fields of 'defaultHints', without inspecting the by-default undefined fields 'addrAddress' and 'addrCanonName'.
-showDefaultHints :: AddrInfo -> String
-showDefaultHints AddrInfo{..} = concat [
-    "AddrInfo {"
-  , "addrFlags = "
-  , show addrFlags
-  , ", addrFamily = "
-  , show addrFamily
-  , ", addrSocketType = "
-  , show addrSocketType
-  , ", addrProtocol = "
-  , show addrProtocol
-  , ", addrAddress = "
-  , "<assumed to be undefined>"
-  , ", addrCanonName = "
-  , "<assumed to be undefined>"
-  , "}"
-  ]
 
 -----------------------------------------------------------------------------
 -- | Resolve a host or service name to one or more addresses.
@@ -294,7 +273,7 @@ getAddrInfo hints node service = alloc getaddrinfo
                         err
     message = concat [
         "Network.Socket.getAddrInfo (called with preferred socket type/protocol: "
-      , maybe (show hints) showDefaultHints hints
+      , maybe "Nothing" show hints
       , ", host name: "
       , show node
       , ", service name: "

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -277,8 +277,8 @@ pattern RecvIPv6PktInfo = SockOpt (-1) (-1)
 data StructLinger = StructLinger CInt CInt
 
 instance Storable StructLinger where
-    sizeOf _ = (#const sizeof(struct linger))
-    alignment _ = alignment (undefined :: CInt)
+    sizeOf ~_    = (#const sizeof(struct linger))
+    alignment ~_ = alignment (0 :: CInt)
 
     peek p = do
         onoff  <- (#peek struct linger, l_onoff) p

--- a/Network/Socket/Posix/Cmsg.hsc
+++ b/Network/Socket/Posix/Cmsg.hsc
@@ -169,8 +169,8 @@ instance ControlMessage IPv4PktInfo where
 
 instance Storable IPv4PktInfo where
 #if defined (IP_PKTINFO)
-    sizeOf _ = (#size struct in_pktinfo)
-    alignment _ = alignment (undefined :: CInt)
+    sizeOf    ~_ = (#size struct in_pktinfo)
+    alignment ~_ = alignment (0 :: CInt)
     poke p (IPv4PktInfo n sa ha) = do
         (#poke struct in_pktinfo, ipi_ifindex)  p (fromIntegral n :: CInt)
         (#poke struct in_pktinfo, ipi_spec_dst) p sa
@@ -181,8 +181,8 @@ instance Storable IPv4PktInfo where
         ha <- (#peek struct in_pktinfo, ipi_addr)     p
         return $ IPv4PktInfo n sa ha
 #else
-    sizeOf _ = 0
-    alignment _ = 1
+    sizeOf    ~_ = 0
+    alignment ~_ = 1
     poke _ _ = error "Unsupported control message type"
     peek _   = error "Unsupported control message type"
 #endif
@@ -200,8 +200,8 @@ instance ControlMessage IPv6PktInfo where
 
 instance Storable IPv6PktInfo where
 #if defined (IPV6_PKTINFO)
-    sizeOf _ = (#size struct in6_pktinfo)
-    alignment _ = alignment (undefined :: CInt)
+    sizeOf    ~_ = (#size struct in6_pktinfo)
+    alignment ~_ = alignment (0 :: CInt)
     poke p (IPv6PktInfo n ha6) = do
         (#poke struct in6_pktinfo, ipi6_ifindex) p (fromIntegral n :: CInt)
         (#poke struct in6_pktinfo, ipi6_addr)    p (In6Addr ha6)
@@ -210,8 +210,8 @@ instance Storable IPv6PktInfo where
         n :: CInt   <- (#peek struct in6_pktinfo, ipi6_ifindex) p
         return $ IPv6PktInfo (fromIntegral n) ha6
 #else
-    sizeOf _ = 0
-    alignment _ = 1
+    sizeOf    ~_ = 0
+    alignment ~_ = 1
     poke _ _ = error "Unsupported control message type"
     peek _   = error "Unsupported control message type"
 #endif

--- a/Network/Socket/Posix/CmsgHdr.hsc
+++ b/Network/Socket/Posix/CmsgHdr.hsc
@@ -28,8 +28,8 @@ data CmsgHdr = CmsgHdr {
   } deriving (Eq, Show)
 
 instance Storable CmsgHdr where
-  sizeOf _    = (#size struct cmsghdr)
-  alignment _ = alignment (undefined :: CInt)
+  sizeOf    ~_ = (#size struct cmsghdr)
+  alignment ~_ = alignment (0 :: CInt)
 
   peek p = do
     len <- (#peek struct cmsghdr, cmsg_len)   p

--- a/Network/Socket/Posix/IOVec.hsc
+++ b/Network/Socket/Posix/IOVec.hsc
@@ -19,8 +19,8 @@ data IOVec = IOVec
     }
 
 instance Storable IOVec where
-  sizeOf _    = (#const sizeof(struct iovec))
-  alignment _ = alignment (undefined :: CInt)
+  sizeOf    ~_ = (#const sizeof(struct iovec))
+  alignment ~_ = alignment (0 :: CInt)
 
   peek p = do
     base <- (#peek struct iovec, iov_base) p

--- a/Network/Socket/Posix/MsgHdr.hsc
+++ b/Network/Socket/Posix/MsgHdr.hsc
@@ -24,8 +24,8 @@ data MsgHdr sa = MsgHdr
     }
 
 instance Storable (MsgHdr sa) where
-  sizeOf _    = (#const sizeof(struct msghdr))
-  alignment _ = alignment (undefined :: CInt)
+  sizeOf    ~_ = (#const sizeof(struct msghdr))
+  alignment ~_ = alignment (0 :: CInt)
 
   peek p = do
     name       <- (#peek struct msghdr, msg_name)       p

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -935,6 +935,7 @@ class SocketAddress sa where
 sockaddrStorageLen :: Int
 sockaddrStorageLen = 128
 
+{-# NOINLINE withSocketAddress #-}
 withSocketAddress :: SocketAddress sa => sa -> (Ptr sa -> Int -> IO a) -> IO a
 withSocketAddress addr f = do
     let sz = sizeOfSocketAddress addr
@@ -1050,6 +1051,9 @@ sizeOfSockAddr SockAddrUnix{}  = error "sizeOfSockAddr: not supported"
 sizeOfSockAddr SockAddrInet{}  = #const sizeof(struct sockaddr_in)
 sizeOfSockAddr SockAddrInet6{} = #const sizeof(struct sockaddr_in6)
 
+-- The combination of "-XString" and inlining results in a bug where
+-- "sz" is always 0.
+{-# NOINLINE withSockAddr #-}
 -- | Use a 'SockAddr' with a function requiring a pointer to a
 -- 'SockAddr' and the length of that 'SockAddr'.
 withSockAddr :: SockAddr -> (Ptr SockAddr -> Int -> IO a) -> IO a

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -910,8 +910,8 @@ foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
 {-# DEPRECATED ntohl "Use getAddrInfo instead" #-}
 
 instance Storable PortNumber where
-   sizeOf    _ = sizeOf    (undefined :: Word16)
-   alignment _ = alignment (undefined :: Word16)
+   sizeOf    ~_ = sizeOf    (0 :: Word16)
+   alignment ~_ = alignment (0 :: Word16)
    poke p (PortNum po) = poke (castPtr p) (htons po)
    peek p = PortNum . ntohs <$> peek (castPtr p)
 
@@ -1221,8 +1221,8 @@ newtype In6Addr = In6Addr HostAddress6
 #endif
 
 instance Storable In6Addr where
-    sizeOf _    = #const sizeof(struct in6_addr)
-    alignment _ = #alignment struct in6_addr
+    sizeOf ~_    = #const sizeof(struct in6_addr)
+    alignment ~_ = #alignment struct in6_addr
 
     peek p = do
         a <- peek32 p 0

--- a/Network/Socket/Unix.hsc
+++ b/Network/Socket/Unix.hsc
@@ -81,8 +81,8 @@ getPeerCred s = do
 
 newtype PeerCred = PeerCred (CUInt, CUInt, CUInt)
 instance Storable PeerCred where
-    sizeOf _ = (#const sizeof(struct ucred))
-    alignment _ = alignment (undefined :: CInt)
+    sizeOf    ~_ = (#const sizeof(struct ucred))
+    alignment ~_ = alignment (0 :: CInt)
     poke _ _ = return ()
     peek p = do
         pid <- (#peek struct ucred, pid) p

--- a/Network/Socket/Win32/Cmsg.hsc
+++ b/Network/Socket/Win32/Cmsg.hsc
@@ -147,8 +147,8 @@ instance ControlMessage IPv4PktInfo where
     controlMessageId = CmsgIdIPv4PktInfo
 
 instance Storable IPv4PktInfo where
-    sizeOf      = const #{size IN_PKTINFO}
-    alignment _ = #alignment IN_PKTINFO
+    sizeOf    ~_ = #{size IN_PKTINFO}
+    alignment ~_ = #alignment IN_PKTINFO
     poke p (IPv4PktInfo n ha) = do
         (#poke IN_PKTINFO, ipi_ifindex)  p (fromIntegral n :: CInt)
         (#poke IN_PKTINFO, ipi_addr)     p ha
@@ -169,8 +169,8 @@ instance ControlMessage IPv6PktInfo where
     controlMessageId = CmsgIdIPv6PktInfo
 
 instance Storable IPv6PktInfo where
-    sizeOf      = const #{size IN6_PKTINFO}
-    alignment _ = #alignment IN6_PKTINFO
+    sizeOf    ~_ = #{size IN6_PKTINFO}
+    alignment ~_ = #alignment IN6_PKTINFO
     poke p (IPv6PktInfo n ha6) = do
         (#poke IN6_PKTINFO, ipi6_ifindex) p (fromIntegral n :: CInt)
         (#poke IN6_PKTINFO, ipi6_addr)    p (In6Addr ha6)

--- a/Network/Socket/Win32/CmsgHdr.hsc
+++ b/Network/Socket/Win32/CmsgHdr.hsc
@@ -25,8 +25,8 @@ data CmsgHdr = CmsgHdr {
   } deriving (Eq, Show)
 
 instance Storable CmsgHdr where
-  sizeOf      = const #{size WSACMSGHDR}
-  alignment _ = #alignment WSACMSGHDR
+  sizeOf    ~_ = #{size WSACMSGHDR}
+  alignment ~_ = #alignment WSACMSGHDR
 
   peek p = do
     len <- (#peek WSACMSGHDR, cmsg_len)   p

--- a/Network/Socket/Win32/MsgHdr.hsc
+++ b/Network/Socket/Win32/MsgHdr.hsc
@@ -28,8 +28,8 @@ data MsgHdr sa = MsgHdr
     } deriving Show
 
 instance Storable (MsgHdr sa) where
-  sizeOf      = const #{size WSAMSG}
-  alignment _ = #alignment WSAMSG
+  sizeOf    ~_ = #{size WSAMSG}
+  alignment ~_ = #alignment WSAMSG
 
   peek p = do
     name       <- (#peek WSAMSG, name)          p

--- a/Network/Socket/Win32/WSABuf.hsc
+++ b/Network/Socket/Win32/WSABuf.hsc
@@ -20,8 +20,8 @@ data WSABuf = WSABuf
     }
 
 instance Storable WSABuf where
-  sizeOf      = const #{size WSABUF}
-  alignment _ = #alignment WSABUF
+  sizeOf    ~_ = #{size WSABUF}
+  alignment ~_ = #alignment WSABUF
 
   peek p = do
     base <- (#peek WSABUF, buf) p

--- a/network.cabal
+++ b/network.cabal
@@ -120,6 +120,9 @@ library
       cpp-options: -D_WIN32_WINNT=0x0600
       cc-options: -D_WIN32_WINNT=0x0600
 
+  if impl(ghc >= 8)
+      default-extensions:  Strict StrictData
+
 test-suite spec
   default-language: Haskell2010
   hs-source-dirs: tests
@@ -143,6 +146,9 @@ test-suite spec
     network,
     hspec >= 2.6
 
+  if impl(ghc >= 8)
+      default-extensions:  Strict StrictData
+
 test-suite doctests
   buildable: False
   default-language: Haskell2010
@@ -156,6 +162,9 @@ test-suite doctests
     network
 
   ghc-options: -Wall
+
+  if impl(ghc >= 8)
+      default-extensions:  Strict StrictData
 
 source-repository head
   type:     git


### PR DESCRIPTION
To avoid unexpected behavior, let's use `Strict` and `StrictData` for version 4. This PR include:

- Introducing the lazy binding for `sizeOf` and `alignment` where `undefined` is typically passed.
- Removing `undefined` as much as possible.

Discussion:

- Due to inlining, `sizeOfSockAddr` returns 0. I don't know why. See 6bff61027ba61b7acc0c5694f2f84a5dc6bf7cd2 for my workaround. Without this commit, the test fails.
- Three `undefined`s still remain. For instance, `siz = sizeOf (undefined :: a)`. We need to check if these do not harm.