### PR TITLE
Socket type and family as CInt patterns

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -134,9 +134,9 @@ module Network.Socket
 
     -- * Socket options
     , SocketOption(SockOpt
-                  ,Debug,ReuseAddr,Type,SoError,DontRoute,Broadcast
-                  ,SendBuffer,RecvBuffer,KeepAlive,OOBInline,TimeToLive
-                  ,MaxSegment,NoDelay,Cork,Linger,ReusePort
+                  ,Debug,ReuseAddr,SoDomain,Type,SoProtocol,SoError,DontRoute
+                  ,Broadcast,SendBuffer,RecvBuffer,KeepAlive,OOBInline
+                  ,TimeToLive,MaxSegment,NoDelay,Cork,Linger,ReusePort
                   ,RecvLowWater,SendLowWater,RecvTimeOut,SendTimeOut
                   ,UseLoopBack,UserTimeout,IPv6Only
                   ,RecvIPv4TTL,RecvIPv4TOS,RecvIPv4PktInfo
@@ -160,11 +160,22 @@ module Network.Socket
     , mkSocket
     , socketToHandle
     -- ** Types of Socket
-    , SocketType(..)
+    , SocketType(GeneralSocketType, UnsupportedSocketType, NoSocketType
+                , Stream, Datagram, Raw, RDM, SeqPacket)
     , isSupportedSocketType
     , getSocketType
     -- ** Family
-    , Family(..)
+    , Family(GeneralFamily, UnsupportedFamily
+            ,AF_UNSPEC,AF_UNIX,AF_INET,AF_INET6,AF_IMPLINK,AF_PUP,AF_CHAOS
+            ,AF_NS,AF_NBS,AF_ECMA,AF_DATAKIT,AF_CCITT,AF_SNA,AF_DECnet
+            ,AF_DLI,AF_LAT,AF_HYLINK,AF_APPLETALK,AF_ROUTE,AF_NETBIOS
+            ,AF_NIT,AF_802,AF_ISO,AF_OSI,AF_NETMAN,AF_X25,AF_AX25,AF_OSINET
+            ,AF_GOSSIP,AF_IPX,Pseudo_AF_XTP,AF_CTF,AF_WAN,AF_SDL,AF_NETWARE
+            ,AF_NDD,AF_INTF,AF_COIP,AF_CNT,Pseudo_AF_RTIP,Pseudo_AF_PIP
+            ,AF_SIP,AF_ISDN,Pseudo_AF_KEY,AF_NATM,AF_ARP,Pseudo_AF_HDRCMPLT
+            ,AF_ENCAP,AF_LINK,AF_RAW,AF_RIF,AF_NETROM,AF_BRIDGE,AF_ATMPVC
+            ,AF_ROSE,AF_NETBEUI,AF_SECURITY,AF_PACKET,AF_ASH,AF_ECONET
+            ,AF_ATMSVC,AF_IRDA,AF_PPPOX,AF_WANPIPE,AF_BLUETOOTH,AF_CAN)
     , isSupportedFamily
     , packFamily
     , unpackFamily

--- a/Network/Socket/Imports.hs
+++ b/Network/Socket/Imports.hs
@@ -7,7 +7,6 @@ module Network.Socket.Imports (
   , module Data.Maybe
   , module Data.Monoid
   , module Data.Ord
-  , module Data.Typeable
   , module Data.Word
   , module Foreign.C.String
   , module Foreign.C.Types
@@ -24,7 +23,6 @@ import Data.List
 import Data.Maybe
 import Data.Monoid
 import Data.Ord
-import Data.Typeable
 import Data.Word
 import Foreign.C.String
 import Foreign.C.Types

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -124,18 +124,17 @@ instance Storable AddrInfo where
                         then return Nothing
                         else Just <$> peekCString ai_canonname_ptr
 
-        socktype <- unpackSocketType' "AddrInfo.peek" ai_socktype
         return $ AddrInfo {
             addrFlags = unpackBits aiFlagMapping ai_flags
           , addrFamily = unpackFamily ai_family
-          , addrSocketType = socktype
+          , addrSocketType = unpackSocketType ai_socktype
           , addrProtocol = ai_protocol
           , addrAddress = ai_addr
           , addrCanonName = ai_canonname
           }
 
     poke p (AddrInfo flags family sockType protocol _ _) = do
-        c_stype <- packSocketTypeOrThrow "AddrInfo.poke" sockType
+        let c_stype = packSocketType sockType
 
         (#poke struct addrinfo, ai_flags) p (packBits aiFlagMapping flags)
         (#poke struct addrinfo, ai_family) p (packFamily family)

--- a/Network/Socket/Info.hsc
+++ b/Network/Socket/Info.hsc
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -63,7 +62,7 @@ data AddrInfoFlag =
     --   addresses are found, IPv6-mapped IPv4 addresses will be
     --   returned. (Only some platforms support this.)
     | AI_V4MAPPED
-    deriving (Eq, Read, Show, Typeable)
+    deriving (Eq, Read, Show)
 
 aiFlagMapping :: [(AddrInfoFlag, CInt)]
 
@@ -106,7 +105,7 @@ data AddrInfo = AddrInfo {
   , addrProtocol :: ProtocolNumber
   , addrAddress :: SockAddr
   , addrCanonName :: Maybe String
-  } deriving (Eq, Show, Typeable)
+  } deriving (Eq, Show)
 
 instance Storable AddrInfo where
     sizeOf    _ = #const sizeof(struct addrinfo)
@@ -170,7 +169,7 @@ data NameInfoFlag =
     --   looked up.  Instead, a numeric representation of the
     --   service is returned.
     | NI_NUMERICSERV
-    deriving (Eq, Read, Show, Typeable)
+    deriving (Eq, Read, Show)
 
 niFlagMapping :: [(NameInfoFlag, CInt)]
 

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -9,8 +9,8 @@
 
 module Network.Socket.Options (
     SocketOption(SockOpt
-                ,Debug,ReuseAddr,Type,SoError,DontRoute,Broadcast
-                ,SendBuffer,RecvBuffer,KeepAlive,OOBInline,TimeToLive
+                ,Debug,ReuseAddr,SoDomain,Type,SoProtocol,SoError,DontRoute
+                ,Broadcast,SendBuffer,RecvBuffer,KeepAlive,OOBInline,TimeToLive
                 ,MaxSegment,NoDelay,Cork,Linger,ReusePort
                 ,RecvLowWater,SendLowWater,RecvTimeOut,SendTimeOut
                 ,UseLoopBack,UserTimeout,IPv6Only
@@ -53,8 +53,7 @@ isSupportedSocketOption opt = opt /= SockOpt (-1) (-1)
 --
 --   Since: 3.0.1.0
 getSocketType :: Socket -> IO SocketType
-getSocketType s = (fromMaybe NoSocketType . unpackSocketType . fromIntegral)
-                    <$> getSocketOption s Type
+getSocketType s = unpackSocketType <$> getSockOpt s Type
 
 #ifdef SOL_SOCKET
 -- | SO_DEBUG
@@ -71,13 +70,31 @@ pattern ReuseAddr      = SockOpt (#const SOL_SOCKET) (#const SO_REUSEADDR)
 #else
 pattern ReuseAddr      = SockOpt (-1) (-1)
 #endif
--- | SO_TYPE
+
+-- | SO_DOMAIN, read-only
+pattern SoDomain :: SocketOption
+#ifdef SO_DOMAIN
+pattern SoDomain       = SockOpt (#const SOL_SOCKET) (#const SO_DOMAIN)
+#else
+pattern SoDomain       = SockOpt (-1) (-1)
+#endif
+
+-- | SO_TYPE, read-only
 pattern Type :: SocketOption
 #ifdef SO_TYPE
 pattern Type           = SockOpt (#const SOL_SOCKET) (#const SO_TYPE)
 #else
 pattern Type           = SockOpt (-1) (-1)
 #endif
+
+-- | SO_PROTOCOL, read-only
+pattern SoProtocol :: SocketOption
+#ifdef SO_PROTOCOL
+pattern SoProtocol     = SockOpt (#const SOL_SOCKET) (#const SO_PROTOCOL)
+#else
+pattern SoProtocol     = SockOpt (-1) (-1)
+#endif
+
 -- | SO_ERROR
 pattern SoError :: SocketOption
 #ifdef SO_ERROR

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 
 #include "HsNetDef.h"
 
@@ -27,7 +26,6 @@ import Network.Socket.Types
 data ShutdownCmd = ShutdownReceive
                  | ShutdownSend
                  | ShutdownBoth
-                 deriving Typeable
 
 sdownCmdToInt :: ShutdownCmd -> CInt
 sdownCmdToInt ShutdownReceive = 0

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -84,7 +84,7 @@ socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
     return s
   where
     create = do
-        c_stype <- modifyFlag <$> packSocketTypeOrThrow "socket" stype
+        let c_stype = modifyFlag $ packSocketType stype
         throwSocketErrorIfMinus1Retry "Network.Socket.socket" $
             c_socket (packFamily family) c_stype protocol
 

--- a/Network/Socket/Unix.hsc
+++ b/Network/Socket/Unix.hsc
@@ -178,7 +178,7 @@ socketPair :: Family              -- Family Name (usually AF_UNIX)
 #if defined(DOMAIN_SOCKET_SUPPORT)
 socketPair family stype protocol =
     allocaBytes (2 * sizeOf (1 :: CInt)) $ \ fdArr -> do
-      c_stype <- packSocketTypeOrThrow "socketPair" stype
+      let c_stype = packSocketType stype
       _rc <- throwSocketErrorIfMinus1Retry "Network.Socket.socketpair" $
                   c_socketpair (packFamily family) c_stype protocol fdArr
       [fd1,fd2] <- peekArray 2 fdArr


### PR DESCRIPTION
The current sum-type model for Socket types and families is not extensible, and
makes it needlessly difficult to perform generic operations on sockets, see
e.g. https://github.com/haskell/network/issues/427

This WIP (not yet done, preview), simplifies the model by replacing the sum
types in question with newtypes around CInt + patterns.  It also adds the
SO_DOMAIN and SO_PROTOCOL options (when available on the target system).

Pre-review requested to sanity check the overall approach.

Open issues:

    - What to do with "Read" instances, now that the types are CInt
    wrappers?  Does anyone need these?

    - What are all the "Typeable" instances about?  I dropped some,
    and the code continues to work.  Does anyone need these?

    - Now conversions between the sum types and the CInt FFI are
    total functions, do we still need to check for unsupported
    values?  Or just pass them through to the API, and the let
    the system calls object to unsupported values?

    - The protocol family passed as the first argument to socket(2)
    and returned getsockopt(SO_DOMAIN) is a CInt, but the corresponding
    address family in sa_family is only an Int8 or Int16.  Perhaps some
    care is required to make sure we don't have code paths that result
    in trunction of the SocketType when creating ai_family/sa_family.