### PR TITLE
Work around historical behavioural oddity with UNIX domain sockets

### DIFF
--- a/Network/Socket/SockAddr.hs
+++ b/Network/Socket/SockAddr.hs
@@ -11,6 +11,10 @@ module Network.Socket.SockAddr (
     , recvBufMsg
     ) where
 
+import Control.Exception (try, throwIO, IOException)
+import System.Directory (removeFile)
+import System.IO.Error (isAlreadyInUseError, isDoesNotExistError)
+
 import qualified Network.Socket.Buffer as G
 import qualified Network.Socket.Name as G
 import qualified Network.Socket.Syscall as G
@@ -41,7 +45,27 @@ connect = G.connect
 -- 'defaultPort' is passed then the system assigns the next available
 -- use port.
 bind :: Socket -> SockAddr -> IO ()
-bind = G.bind
+bind s a = case a of
+  SockAddrUnix p -> do
+    -- gracefully handle the fact that UNIX systems don't clean up closed UNIX
+    -- domain sockets, inspired by https://stackoverflow.com/a/13719866
+    res <- try (G.bind s a)
+    case res of
+      Right () -> pure ()
+      Left e -> if not (isAlreadyInUseError (e :: IOException))
+        then throwIO e
+        else do
+          -- socket might be in use, try to connect
+          res2 <- try (G.connect s a)
+          case res2 of
+            Right () -> close s >> throwIO e
+            Left e2 -> if not (isDoesNotExistError (e2 :: IOException))
+              then throwIO e
+              else do
+                -- socket not actually in use, remove it and retry bind
+                removeFile p
+                G.bind s a
+  _ -> G.bind s a
 
 -- | Accept a connection.  The socket must be bound to an address and
 -- listening for connections.  The return value is a pair @(conn,

--- a/network.cabal
+++ b/network.cabal
@@ -142,6 +142,7 @@ test-suite spec
     directory,
     HUnit,
     network,
+    temporary,
     hspec >= 2.6
 
 test-suite doctests

--- a/network.cabal
+++ b/network.cabal
@@ -83,7 +83,8 @@ library
   build-depends:
     base >= 4.7 && < 5,
     bytestring == 0.10.*,
-    deepseq
+    deepseq,
+    directory
 
   include-dirs: include
   includes: HsNet.h HsNetDef.h alignment.h win32defs.h

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -77,7 +77,8 @@ spec = do
                     sock1 <- socket AF_UNIX Stream defaultProtocol
                     tryIOError (bind sock1 addr) >>= \o -> case o of
                         Right () -> error "bind should have failed but succeeded"
-                        Left e -> if isAlreadyInUseError e then pure () else ioError e
+                        Left e | not (isAlreadyInUseError e) -> ioError e
+                        _ -> return ()
 
                     close sock0
 


### PR DESCRIPTION
Originally part of #428. Hopefully the code & commit messages should be self-explanatory. TD;LR version is that bind doesn't clean up after itself, this works around that.