### PR TITLE
Precedence-compliant Read/Show instances using Bijective pairs for patterns 

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -245,6 +245,7 @@ module Network.Socket
             ,CmsgIdIPv6TClass
             ,CmsgIdIPv4PktInfo
             ,CmsgIdIPv6PktInfo
+            ,CmsgIdFd
             ,UnsupportedCmsgId)
     -- ** APIs for control message
     , lookupCmsg

--- a/Network/Socket/Posix/Cmsg.hsc
+++ b/Network/Socket/Posix/Cmsg.hsc
@@ -229,8 +229,8 @@ instance Storable IPv6PktInfo where
 instance ControlMessage Fd where
     controlMessageId = CmsgIdFd
 
-cmsgIdPairs :: [Pair CmsgId String]
-cmsgIdPairs =
+cmsgIdBijection :: Bijection CmsgId String
+cmsgIdBijection =
     [ (UnsupportedCmsgId, "UnsupportedCmsgId")
     , (CmsgIdIPv4TTL, "CmsgIdIPv4TTL")
     , (CmsgIdIPv6HopLimit, "CmsgIdIPv6HopLimit")
@@ -241,17 +241,17 @@ cmsgIdPairs =
     , (CmsgIdFd, "CmsgIdFd")
     ]
 
-cmsgIdBijection :: Bijection CmsgId String
-cmsgIdBijection = Bijection{..}
-    where
+instance Show CmsgId where
+    showsPrec = bijectiveShow cmsgIdBijection def
+      where
         defname = "CmsgId"
         unId = \(CmsgId l t) -> (l,t)
-        defFwd = defShow defname unId _show
-        defBwd = defRead defname (uncurry CmsgId) _parse
-        pairs = cmsgIdPairs
-
-instance Show CmsgId where
-    show = forward cmsgIdBijection
+        def = defShow defname unId showIntInt
 
 instance Read CmsgId where
-    readPrec = tokenize $ backward cmsgIdBijection
+    readPrec = bijectiveRead cmsgIdBijection def
+      where
+        defname = "CmsgId"
+        def = defRead defname (uncurry CmsgId) readIntInt
+
+    

--- a/Network/Socket/Win32/Cmsg.hsc
+++ b/Network/Socket/Win32/Cmsg.hsc
@@ -66,8 +66,11 @@ pattern CmsgIdIPv4PktInfo = CmsgId (#const IPPROTO_IP) (#const IP_PKTINFO)
 pattern CmsgIdIPv6PktInfo :: CmsgId
 pattern CmsgIdIPv6PktInfo = CmsgId (#const IPPROTO_IPV6) (#const IPV6_PKTINFO)
 
--- Use WSADuplicateSocket for CmsgIdFd
--- pattern CmsgIdFd :: CmsgId
+-- | Control message ID for POSIX file-descriptor passing.
+--
+--  Not supported on Windows; use WSADuplicateSocket instead
+pattern CmsgIdFd :: CmsgId
+pattern CmsgIdFd = CmsgId (-1) (-1)
 
 ----------------------------------------------------------------
 
@@ -196,6 +199,7 @@ cmsgIdPairs =
     , (CmsgIdIPv6TClass, "CmsgIdIPv6TClass")
     , (CmsgIdIPv4PktInfo, "CmsgIdIPv4PktInfo")
     , (CmsgIdIPv6PktInfo, "CmsgIdIPv6PktInfo")
+    , (CmsgIdFd, "CmsgIdFd")
     ]
 
 cmsgIdBijection :: Bijection CmsgId String

--- a/Network/Socket/Win32/Cmsg.hsc
+++ b/Network/Socket/Win32/Cmsg.hsc
@@ -190,8 +190,8 @@ instance Storable IPv6PktInfo where
         n :: ULONG  <- (#peek IN6_PKTINFO, ipi6_ifindex) p
         return $ IPv6PktInfo (fromIntegral n) ha6
 
-cmsgIdPairs :: [Pair CmsgId String]
-cmsgIdPairs =
+cmsgIdBijection :: Bijection CmsgId String
+cmsgIdBijection =
     [ (UnsupportedCmsgId, "UnsupportedCmsgId")
     , (CmsgIdIPv4TTL, "CmsgIdIPv4TTL")
     , (CmsgIdIPv6HopLimit, "CmsgIdIPv6HopLimit")
@@ -202,17 +202,15 @@ cmsgIdPairs =
     , (CmsgIdFd, "CmsgIdFd")
     ]
 
-cmsgIdBijection :: Bijection CmsgId String
-cmsgIdBijection = Bijection{..}
-    where
+instance Show CmsgId where
+    showsPrec = bijectiveShow cmsgIdBijection def
+      where
         defname = "CmsgId"
         unId = \(CmsgId l t) -> (l,t)
-        defFwd = defShow defname unId _show
-        defBwd = defRead defname (uncurry CmsgId) _parse
-        pairs = cmsgIdPairs
-
-instance Show CmsgId where
-    show = forward cmsgIdBijection
+        def = defShow defname unId showIntInt
 
 instance Read CmsgId where
-    readPrec = tokenize $ backward cmsgIdBijection
+    readPrec = bijectiveRead cmsgIdBijection def
+      where
+        defname = "CmsgId"
+        def = defRead defname (uncurry CmsgId) readIntInt

--- a/network.cabal
+++ b/network.cabal
@@ -144,7 +144,8 @@ test-suite spec
     HUnit,
     network,
     temporary,
-    hspec >= 2.6
+    hspec >= 2.6,
+    QuickCheck
 
 test-suite doctests
   buildable: False


### PR DESCRIPTION
Adapts bijective read/show boilerplate in Network.Socket.ReadShow to be precedence-sensitive while maintaining full generality of base implementation.

Re-implements bijective read/show instances for SocketOption, SocketType, Family, and CmsgId.