### PR TITLE
[Experimental] WIP newtype redefinition of ProtocolNumber

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -181,8 +181,14 @@ module Network.Socket
     , packFamily
     , unpackFamily
     -- ** Protocol number
-    , ProtocolNumber
+    , ProtocolNumber(UnsupportedProtocol,GeneralProtocol
+                    ,IPPROTO_IP,IPPROTO_IPV4,IPPROTO_IPV6
+                    ,IPPROTO_UDP,IPPROTO_TCP
+                    ,IPPROTO_ICMP,IPPROTO_ICMPV6,IPPROTO_RAW
+                    )
     , defaultProtocol
+    , packProtocol
+    , unpackProtocol
     -- * Basic socket address type
     , SockAddr(..)
     , isSupportedSockAddr

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -86,7 +86,7 @@ socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
     create = do
         let c_stype = modifyFlag $ packSocketType stype
         throwSocketErrorIfMinus1Retry "Network.Socket.socket" $
-            c_socket (packFamily family) c_stype protocol
+            c_socket (packFamily family) c_stype (packProtocol protocol)
 
 #ifdef HAVE_ADVANCED_SOCKET_FLAGS
     modifyFlag c_stype = c_stype .|. sockNonBlock

--- a/Network/Socket/Unix.hsc
+++ b/Network/Socket/Unix.hsc
@@ -180,7 +180,7 @@ socketPair family stype protocol =
     allocaBytes (2 * sizeOf (1 :: CInt)) $ \ fdArr -> do
       let c_stype = packSocketType stype
       _rc <- throwSocketErrorIfMinus1Retry "Network.Socket.socketpair" $
-                  c_socketpair (packFamily family) c_stype protocol fdArr
+                  c_socketpair (packFamily family) c_stype (packProtocol protocol) fdArr
       [fd1,fd2] <- peekArray 2 fdArr
       setNonBlockIfNeeded fd1
       setNonBlockIfNeeded fd2

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -352,6 +352,23 @@ spec = do
             let socktype = GeneralSocketType (-300) in
             show socktype `shouldBe` "GeneralSocketType (-300)"
 
+    describe "show ProtocolNumber" $ do
+        it "works for pattern synonyms" $
+            let proto = IPPROTO_IP in
+            show proto `shouldBe` "IPPROTO_IP"
+
+        it "works for unsupported" $
+            let proto = GeneralProtocol (-1) in
+            show proto `shouldBe` "UnsupportedProtocol"
+
+        it "works for positive values" $
+            let proto = GeneralProtocol 300 in
+            show proto `shouldBe` "300"
+
+        it "works for negative values" $
+            let proto = GeneralProtocol (-300) in
+            show proto `shouldBe` "-300"
+
     describe "show SocketOptions" $ do
         it "works for pattern synonyms" $
             let opt = ReuseAddr in
@@ -393,6 +410,9 @@ spec = do
         it "holds for SocketType" $ forAll socktypeGen $
             \x -> (read . show $ x) == (x :: SocketType)
 
+        it "holds for ProtocolNumber" $ forAll protoGen $
+            \x -> (read . show $ x) == (x :: ProtocolNumber)
+
         it "holds for SocketOption" $ forAll sockoptGen $
             \x -> (read . show $ x) == (x :: SocketOption)
 
@@ -416,6 +436,9 @@ familyGen = biasedGen (fmap GeneralFamily) familyPatterns arbitrary
 
 socktypeGen :: Gen SocketType
 socktypeGen = biasedGen (fmap GeneralSocketType) socktypePatterns arbitrary
+
+protoGen :: Gen ProtocolNumber
+protoGen = biasedGen (fmap GeneralProtocol) protoPatterns arbitrary
 
 sockoptGen :: Gen SocketOption
 sockoptGen = biasedGen (\g -> SockOpt <$> g <*> g) sockoptPatterns arbitrary
@@ -472,3 +495,17 @@ cmsgidPatterns = nub
     , CmsgIdIPv6PktInfo
     , CmsgIdFd
     ]
+
+protoPatterns :: [ProtocolNumber]
+protoPatterns = nub
+    [ UnsupportedProtocol
+    , IPPROTO_IP
+    , IPPROTO_IPV4
+    , IPPROTO_IPV6
+    , IPPROTO_UDP
+    , IPPROTO_TCP
+    , IPPROTO_ICMP
+    , IPPROTO_ICMPV6
+    , IPPROTO_RAW
+    ]
+


### PR DESCRIPTION
redefines ProtocolNumber as newtype around CInt (formerly type alias for CInt)
that re-derives all instance methods for CInt that are defined in Foreign.C.Types

defines and exports pattern synonyms for commonly used protocol-number constants (defined in "netinet/in.h")
(IPPROTO_(IP|IPV4|IPV6|TCP|UDP|ICMP|ICMPV6|RAW)) as well as UnsupportedProtocol and GeneralProtocol patterns

refactored function definitions previously relying on (ProtocolNumber ~ CInt) to use unwrapper function

implements bijective read/show instances for ProtocolNumber whose default behavior is to directly read and show integer values with no constructor syntax