### PR TITLE
adding "devel" flag to run test cases which may fail.

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -54,6 +54,10 @@ tested-with:   GHC == 8.0.2
              , GHC == 8.8.3
              , GHC == 8.10.1
 
+flag devel
+  description:          using tests for developers
+  default:              False
+
 library
   default-language: Haskell2010
   exposed-modules:
@@ -126,6 +130,8 @@ test-suite spec
   default-language: Haskell2010
   hs-source-dirs: tests
   main-is: Spec.hs
+  if flag(devel)
+    cpp-options:  -DDEVELOPMENT
   other-modules:
     Network.Test.Common
     Network.SocketSpec

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -58,6 +58,7 @@ spec = do
             bind sock (addrAddress addr) `shouldThrow` anyIOException
 -}
 
+#ifdef DEVELOPMENT
         it "successfully binds to an ipv6 socket" $ do
             addr:_ <- getAddrInfo (Just hints) (Just serverAddr6) Nothing
             sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
@@ -67,6 +68,7 @@ spec = do
             addr:_ <- getAddrInfo (Just hints) (Just "::6") Nothing
             sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
             bind sock (addrAddress addr) `shouldThrow` anyIOException
+#endif
 
         it "successfully binds to a unix socket, twice" $ do
             withSystemTempDirectory "haskell-network" $ \path -> do


### PR DESCRIPTION
This should fix #439.

When we maintainers test this library on local machines, `-f devel` should be specified.

@tim2CF Sorry for the delay. It took time to hit upon this idea. Would you take a look?