### PR TITLE
Increase base lower bound to 4.9

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -86,7 +86,7 @@ library
     Network.Socket.Types
 
   build-depends:
-    base >= 4.7 && < 5,
+    base >= 4.9 && < 5,
     bytestring == 0.10.*,
     deepseq,
     directory


### PR DESCRIPTION
Reason for increase:

- Module `Network.Socket.Posix.Cmsg` uses GHC's Type Applications extension to the Haskell language.

- `TypeApplications` was introduced in GHC 8.0.1 (https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-TypeApplications).

- GHC 8.0.1 shipped with `base-4.9.0.0` (https://wiki.haskell.org/Base_package).