### PR TITLE
Suppress errors from removeFile in UNIX bind

### DIFF
--- a/Network/Socket/SockAddr.hs
+++ b/Network/Socket/SockAddr.hs
@@ -61,7 +61,7 @@ bind s a = case a of
           Left e2 | not (isDoesNotExistError e2) -> throwIO (e2 :: IOException)
           _ -> do
             -- socket not actually in use, remove it and retry bind
-            removeFile p
+            void (try $ removeFile p :: IO (Either IOError ()))
             G.bind s a
   _ -> G.bind s a
 


### PR DESCRIPTION
`removeFile` may fail to delete socket because of lack of permissions, and throw an error which is unrelated to `bind()` itself.