### PR TITLE
Restore missing functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: Binaries
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  pull_request:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["8.6.5", "8.8.3", "8.10.2"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            ghc: 8.8.3
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-haskell@v1
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - uses: actions/cache@v2
+        name: Cache cabal store
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-newstyle
+          key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('network.cabal') }}-${{ github.sha }}
+          restore-keys: |
+            cache-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('network.cabal') }}-
+
+      - name: Set some window specific things
+        if: matrix.os == 'windows-latest'
+        run: echo '::set-env name=EXE_EXT::.exe'
+
+      - uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          update: true
+          install: autoconf
+
+      - if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        run: autoreconf -i
+
+      - if: matrix.os != 'windows-latest'
+        run: autoreconf -i
+
+      - name: Configure project
+        run: cabal configure --enable-tests --enable-benchmarks
+
+      - name: Temp directory
+        env:
+          CLI_TEMP: ${{runner.temp}}
+        run: echo "$CLI_TEMP"
+
+      - name: Build
+        run: |
+          cabal build all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+      && \
+          cabal build all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+ -j2  && \
+          cabal build all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+ -j1
+
+      - name: Test
+        run: |
+          cabal test all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+

--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -208,14 +208,12 @@ module Network.Socket
     , socketPortSafe
     , socketPort
 
-#if !defined(mingw32_HOST_OS)
     -- * UNIX-domain socket
     , isUnixDomainSocketAvailable
     , socketPair
     , sendFd
     , recvFd
     , getPeerCredential
-#endif
 
     -- * Name information
     , getNameInfo
@@ -278,9 +276,9 @@ import Network.Socket.Shutdown
 import Network.Socket.SockAddr
 import Network.Socket.Syscall hiding (connect, bind, accept)
 import Network.Socket.Types
+import Network.Socket.Unix
 #if !defined(mingw32_HOST_OS)
 import Network.Socket.Posix.Cmsg
-import Network.Socket.Unix
 #else
 import Network.Socket.Win32.Cmsg
 #endif


### PR DESCRIPTION
Hmmm, looks like fixing this is going to need more work.

Anyhow, with the Github Workflows that support Windows builds should unblock you from being able verifying that Windows builds work.  https://github.com/haskell/network/pull/486