### PR TITLE
Export StructLinger

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -142,6 +142,7 @@ module Network.Socket
                   ,UseLoopBack,UserTimeout,IPv6Only
                   ,RecvIPv4TTL,RecvIPv4TOS,RecvIPv4PktInfo
                   ,RecvIPv6HopLimit,RecvIPv6TClass,RecvIPv6PktInfo)
+    , StructLinger (..)
     , isSupportedSocketOption
     , whenSupported
     , getSocketOption

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -323,6 +323,7 @@ data StructLinger = StructLinger {
     -- | Linger timeout.
     sl_linger :: CInt
   }
+  deriving (Eq, Ord, Show)
 
 instance Storable StructLinger where
     sizeOf    _ = (#const sizeof(struct linger))

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -25,6 +25,7 @@ module Network.Socket.Options (
   , setSocketOption
   , getSockOpt
   , setSockOpt
+  , StructLinger (..)
   ) where
 
 import qualified Text.Read as P
@@ -313,7 +314,15 @@ pattern CustomSockOpt xy <- ((\(SockOpt x y) -> (x, y)) -> xy)
 {-# COMPLETE CustomSockOpt #-}
 #endif
 #ifdef SO_LINGER
-data StructLinger = StructLinger CInt CInt
+-- | Low level 'SO_LINBER' option value, which can be used with 'setSockOpt'.
+--
+data StructLinger = StructLinger {
+    -- | Set the linger option on.
+    sl_onoff  :: CInt,
+
+    -- | Linger timeout.
+    sl_linger :: CInt
+  }
 
 instance Storable StructLinger where
     sizeOf    _ = (#const sizeof(struct linger))


### PR DESCRIPTION
StructLinger is useful to set linger option on, with 0 interval using
`setSockOpt`.  This is useful to make 'close' set the RST flag on FIN
packet (reset the connection).  This is not possible with a higher level
`setSocketOption`.

This patch also adds record fields to the `StructLinger` record and
adds haddoc documentation.