### PR TITLE
Fix calls to varargs C function fcntl

### DIFF
--- a/Network/Socket/Fcntl.hs
+++ b/Network/Socket/Fcntl.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 
 module Network.Socket.Fcntl where
@@ -27,7 +28,7 @@ setCloseOnExecIfNeeded fd = System.Posix.Internals.setCloseOnExec fd
 #endif
 
 #if !defined(mingw32_HOST_OS)
-foreign import ccall unsafe "fcntl"
+foreign import capi unsafe "fcntl.h fcntl"
   c_fcntl_read  :: CInt -> CInt -> CInt -> IO CInt
 #endif
 


### PR DESCRIPTION
The ccall calling convention doesn't support varargs functions, so
switch to capi instead. See
https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/ffi.html#varargs-not-supported-by-ccall-calling-convention