### PR TITLE
Fix a couple of broken tests on OpenBSD

### DIFF
--- a/Network/Socket/Posix/Cmsg.hsc
+++ b/Network/Socket/Posix/Cmsg.hsc
@@ -44,7 +44,7 @@ pattern UnsupportedCmsgId = CmsgId (-1) (-1)
 
 -- | The identifier for 'IPv4TTL'.
 pattern CmsgIdIPv4TTL :: CmsgId
-#if defined(darwin_HOST_OS) || defined(freebsd_HOST_OS)
+#if defined(darwin_HOST_OS) || defined(freebsd_HOST_OS) || defined(openbsd_HOST_OS)
 pattern CmsgIdIPv4TTL = CmsgId (#const IPPROTO_IP) (#const IP_RECVTTL)
 #else
 pattern CmsgIdIPv4TTL = CmsgId (#const IPPROTO_IP) (#const IP_TTL)
@@ -131,7 +131,7 @@ decodeCmsg (Cmsg cmsid (PS fptr off len))
 ----------------------------------------------------------------
 
 -- | Time to live of IPv4.
-#if defined(darwin_HOST_OS) || defined(freebsd_HOST_OS)
+#if defined(darwin_HOST_OS) || defined(freebsd_HOST_OS) || defined(openbsd_HOST_OS)
 newtype IPv4TTL = IPv4TTL CChar deriving (Eq, Show, Storable)
 #else
 newtype IPv4TTL = IPv4TTL CInt deriving (Eq, Show, Storable)

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -131,7 +131,7 @@ spec = do
 
 #if defined(mingw32_HOST_OS)
     let lpdevname = "loopback_0"
-#elif defined(darwin_HOST_OS) || defined(freebsd_HOST_OS)
+#elif defined(darwin_HOST_OS) || defined(freebsd_HOST_OS) || defined(openbsd_HOST_OS)
     let lpdevname = "lo0"
 #else
     let lpdevname = "lo"


### PR DESCRIPTION
Simply add a defined(openbsd_HOST_OS) check to follow FreeBSD lead.
Fixed tests:
  /Network.Socket.ByteString/recvMsg/receives control messages for IPv4/
  /Network.Socket/ifNameToIndex and ifIndexToName/convert a name to an index and back/