### PR TITLE
update Github Actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10.4', '8.10.5']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10.4']
         exclude:
         - os: windows-latest
           ghc: "8.0"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,12 +10,13 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10.4', '8.10.5']
         exclude:
         - os: windows-latest
           ghc: "8.0"
@@ -40,10 +41,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2'
+        cabal-version: '3.4'
 
     - name: Cache
       uses: actions/cache@v1


### PR DESCRIPTION
uses https://github.com/haskell/actions/tree/main/setup

Most of the jobs succeed: https://github.com/peterbecich/network/actions/runs/937854408

There appears to be an issue with GHC 8.10.5: https://github.com/peterbecich/network/runs/2825581809?check_suite_focus=true
https://github.com/haskell/network/issues/500

I'm not sure if the Windows build issue (https://github.com/peterbecich/network/runs/2825581836?check_suite_focus=true) is the same as https://github.com/haskell/network/issues/487
