### PR TITLE
Use a working define for OpenBSD detection

### DIFF
--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -106,7 +106,7 @@ socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
       -- The IPv6Only option is only supported on Windows Vista and later,
       -- so trying to change it might throw an error.
       setSocketOption s IPv6Only 0 `catchIOError` \_ -> return ()
-# elif defined(__OpenBSD__)
+# elif defined(openbsd_HOST_OS)
       -- don't change IPv6Only
       return ()
 # else


### PR DESCRIPTION
This fixes "receives control messages for IPv6" test and more
importantly every other kind of ipv6 socket creation. E.g. this
no longer happens:
```
*Main> :m +*Network.Test.Common
*Network.Test.Common *Main> addr1:_ <- getAddrInfo Nothing (Just "::1") (Just "5000")
*Network.Test.Common *Main> sock <- socket (addrFamily addr1) (addrSocketType addr1) (addrProtocol addr1)
*** Exception: Network.Socket.setSockOpt: invalid argument (Invalid argument)
```