### PR TITLE
downgrade autoconf to 2.69

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -66,6 +66,14 @@ jobs:
     - if: matrix.os == 'windows-latest'
       shell: msys2 {0}
       run: autoreconf -i
+    # Temporary hack to get around #502 while cabal is fixed.
+    # Force autoconf to 2.69, remove when cabal fixed.
+    - if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: |
+        pacman -R autoconf
+        wget http://repo.msys2.org/msys/x86_64/autoconf-2.69-5-any.pkg.tar.xz
+        pacman -U autoconf-2.69-5-any.pkg.tar.xz
     - if: matrix.os != 'windows-latest'
       run: |
         autoreconf -i

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -71,9 +71,9 @@ jobs:
     - if: matrix.os == 'windows-latest'
       shell: msys2 {0}
       run: |
-        pacman -R autoconf
+        pacman -R --noconfirm autoconf
         wget http://repo.msys2.org/msys/x86_64/autoconf-2.69-5-any.pkg.tar.xz
-        pacman -U autoconf-2.69-5-any.pkg.tar.xz
+        pacman -U --noconfirm autoconf-2.69-5-any.pkg.tar.xz
     - if: matrix.os != 'windows-latest'
       run: |
         autoreconf -i

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -63,17 +63,14 @@ jobs:
       with:
         update: true
         install: autoconf
+    # Temporary hack to get around #502 while cabal is fixed.
+    # remove when cabal fixed.
+    - if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: echo 'PATH_SEPARATOR=";"' >> $GITHUB_ENV
     - if: matrix.os == 'windows-latest'
       shell: msys2 {0}
       run: autoreconf -i
-    # Temporary hack to get around #502 while cabal is fixed.
-    # Force autoconf to 2.69, remove when cabal fixed.
-    - if: matrix.os == 'windows-latest'
-      shell: msys2 {0}
-      run: |
-        pacman -R --noconfirm autoconf
-        wget http://repo.msys2.org/msys/x86_64/autoconf-2.69-5-any.pkg.tar.xz
-        pacman -U --noconfirm autoconf-2.69-5-any.pkg.tar.xz
     - if: matrix.os != 'windows-latest'
       run: |
         autoreconf -i


### PR DESCRIPTION
Workaround for #502

I've explicitly chosen to do a downgrade (since pacman can't install specific version) so that it's easier to remove the workaround later.  Just remove the code added here.