### PR TITLE
Bump to 3.1.2.4 to fix #513

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 3.1.2.4
+
+* Regenerate `configure` script with autoconf-2.69 to temporarily fix broken cabal-3.4.0.0
+  [#513](https://github.com/haskell/network/issues/513)
+
 ## Version 3.1.2.3
 
 * Supporting M1 Mac

--- a/network.cabal
+++ b/network.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.18
 name:           network
-version:        3.1.2.3
+version:        3.1.2.4
 license:        BSD3
 license-file:   LICENSE
 maintainer:     Kazu Yamamoto, Evan Borden


### PR DESCRIPTION
As discussed in https://github.com/haskell/network/issues/513#issuecomment-937841958 regenerating `configure` with `autoconf-2.69` will fix build failures for cabal-3.4.0.0 on windows and unbreak CIs.

It's not a long-term fix, but gives us time to prepare the community for either 3.6+ or a bugfix release 3.4.1.0.

I'm guessing @kazu-yamamoto wants to generate the sdist tarball himself?