### PR TITLE
Bump to 3.1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 3.1.2.4
+## Version 3.1.2.5
 
 * Regenerate `configure` script with autoconf-2.69 to temporarily fix broken cabal-3.4.0.0 on Windows. Note that the old one was generated with autoconf-2.71.
   [#513](https://github.com/haskell/network/issues/513)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([Haskell network package],
-        [3.1.2.3],
+        [3.1.2.5],
         [libraries@haskell.org],
         [network])
 

--- a/network.cabal
+++ b/network.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.18
 name:           network
-version:        3.1.2.4
+version:        3.1.2.5
 license:        BSD3
 license-file:   LICENSE
 maintainer:     Kazu Yamamoto, Evan Borden


### PR DESCRIPTION
Same as https://github.com/haskell/network/pull/514

@kazu-yamamoto the `configure` script is not part of this repo, so I generated the tarball and uploaded it here:

* https://downloads.haskell.org/~ghcup/tmp/network-3.1.2.5.tar.gz
* PGP signature https://downloads.haskell.org/~ghcup/tmp/network-3.1.2.5.tar.gz.sig (my key is `7784930957807690A66EBDBE3786C5262ECB4A3F`)