### PR TITLE
Remove CI workaround for cabal bug

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,7 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     needs: autoconf
 


### PR DESCRIPTION
This workaround caused the cabal-3.4.0.0 issue to leak into production.

----

This PR:

* removes the workaround
* bootstraps `configure` in an ubuntu container with a pre-defined autoconf version
* uploads the sdist as a build artifact
* on tag pushes, will also draft a release with the sdist attached