### PR TITLE
Remove CI timeout

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,6 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
 
     needs: autoconf
 


### PR DESCRIPTION
Is there a reason we have set a timeout in our CI? Unless we really need it, I'd advise to remove it. It's hard to get the timeout value right and having the CI failing on master is discouraging.

My 2c, thanks for the great library!