### PR TITLE
Fix bitsize of cmsgHdrLen and msgCtrlLen on Posix

### DIFF
--- a/Network/Socket/Posix/MsgHdr.hsc
+++ b/Network/Socket/Posix/MsgHdr.hsc
@@ -15,11 +15,19 @@ import Network.Socket.Posix.IOVec (IOVec)
 
 data MsgHdr sa = MsgHdr
     { msgName    :: !(Ptr sa)
-    , msgNameLen :: !CUInt
+    , msgNameLen :: !(#type socklen_t)
     , msgIov     :: !(Ptr IOVec)
+#ifdef __linux__
     , msgIovLen  :: !CSize
+#else
+    , msgIovLen  :: !CInt
+#endif
     , msgCtrl    :: !(Ptr Word8)
-    , msgCtrlLen :: !CInt
+#ifdef __linux__
+    , msgCtrlLen :: !CSize
+#else
+    , msgCtrlLen :: !(#type socklen_t)
+#endif
     , msgFlags   :: !CInt
     }
 

--- a/cbits/cmsg.c
+++ b/cbits/cmsg.c
@@ -87,11 +87,11 @@ unsigned char *cmsg_data(struct cmsghdr *cmsg) {
   return (CMSG_DATA(cmsg));
 }
 
-int cmsg_space(int l) {
+size_t cmsg_space(size_t l) {
   return (CMSG_SPACE(l));
 }
 
-int cmsg_len(int l) {
+size_t cmsg_len(size_t l) {
   return (CMSG_LEN(l));
 }
 #endif /* _WIN32 */

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -126,11 +126,11 @@ cmsg_nxthdr(struct msghdr *mhdr, struct cmsghdr *cmsg);
 extern unsigned char *
 cmsg_data(struct cmsghdr *cmsg);
 
-extern int
-cmsg_space(int l);
+extern size_t
+cmsg_space(size_t l);
 
-extern int
-cmsg_len(int l);
+extern size_t
+cmsg_len(size_t l);
 #endif /* _WIN32 */
 
 INLINE int


### PR DESCRIPTION
These fields are size_t, so using CInt on LP64 only accesses 32 bits
of the total 64.  This is especially noticable on big endian, where
the lower 32 bits of the number are written to the upper 32 bits of
the field.