### PR TITLE
Relax bytestring upper bound

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -87,7 +87,7 @@ library
 
   build-depends:
     base >= 4.7 && < 5,
-    bytestring == 0.10.*,
+    bytestring >= 0.10 && < 0.12,
     deepseq,
     directory
 


### PR DESCRIPTION
GHC 9.6.1 comes with `bytestring-0.11.4.0`.

Tested by building on Windows with Stack and `stack.yaml`:
~~~yaml
resolver: ghc-9.6.1
packages:
- .
~~~