### PR TITLE
Reform CI: caching, cabal check/haddock, latest GHCs

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -67,42 +67,61 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ 'ubuntu-latest', 'macOS-latest', 'windows-latest' ]
-        ghc: [ '8.10', '9.0', '9.2' ]
+        ghc: [ '8.10', '9.0', '9.2', '9.4', '9.6' ]
 
     steps:
     - uses: actions/checkout@v3
 
     - uses: haskell/actions/setup@v2
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.8'
+        cabal-version: latest
+        cabal-update:  true
 
     - uses: actions/download-artifact@v3
       with:
         name: configure
 
-    - name: Cache
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-cabal
+    - name: Haskell versions
+      shell: bash
+      run: |
+        echo "GHC_VERSION=$(ghc --numeric-version)" >> "${GITHUB_ENV}"
+        echo "CABAL_VERSION=$(cabal --numeric-version)" >> "${GITHUB_ENV}"
+
+    - name: Cabal configure
+      run: |
+        cabal configure --enable-tests --disable-benchmarks --disable-documentation
+
+    - name: Cache (restore)
+      uses: actions/cache/restore@v3
+      id:   cache
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: build-${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-sha-${{ github.sha }}
+          # Append commit SHA so that new cache is always written.
+          # This is fine as long as we do not hit the total cache limit of 10GB.
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+             build-${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-
+             build-${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-
 
     - name: Install dependencies
       run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --disable-benchmarks
+        cabal build --only-dependencies
+
+    - name: Cache (save)
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key:  ${{ steps.cache.outputs.cache-primary-key }}
 
     - name: Build
-      run: cabal build --enable-tests --disable-benchmarks all
+      run: |
+        cabal build all
 
     - name: Run tests
-      run: cabal test --test-show-details=streaming
+      run: |
+        cabal test --test-show-details=streaming
 
     - name: Run doctest
       if: ${{ runner.os == 'Linux' }}
@@ -110,20 +129,30 @@ jobs:
         cabal install doctest --overwrite-policy=always
         cabal repl --build-depends=QuickCheck --with-ghc=doctest
 
+    - name: Cabal check
+      run: |
+        cabal check
+
+    - name: Haddock
+      run: |
+        cabal haddock --disable-documentation
+
     # check windows can generate autoconf too
     - uses: msys2/setup-msys2@v2
-      if: matrix.os == 'windows-latest'
+      if:   ${{ runner.os == 'Windows' }}
       with:
         update: true
         install: autoconf
-    - if: matrix.os == 'windows-latest'
-      name: autoreconf
+
+    - name: Autoreconf (Windows)
+      if:   ${{ runner.os == 'Windows' }}
       shell: msys2 {0}
       run: |
         rm configure include/HsNetworkConfig.h.in
         autoreconf -i
-    - if: matrix.os == 'windows-latest'
-      name: Build
+
+    - name: Build (Windows)
+      if:   ${{ runner.os == 'Windows' }}
       run: |
         cabal clean
         cabal build --enable-tests --disable-benchmarks all

--- a/network.cabal
+++ b/network.cabal
@@ -4,9 +4,18 @@ version:            3.1.2.8
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto, Evan Borden
+
 tested-with:
-    ghc ==8.0.2 ghc ==8.2.2 ghc ==8.4.4 ghc ==8.6.5 ghc ==8.8.3
-    ghc ==8.10.1
+    GHC == 9.6.1
+    GHC == 9.4.4
+    GHC == 9.2.7
+    GHC == 9.0.2
+    GHC == 8.10.7
+    GHC == 8.8.4
+    GHC == 8.6.5
+    GHC == 8.4.4
+    GHC == 8.2.2
+    GHC == 8.0.2
 
 homepage:           https://github.com/haskell/network
 bug-reports:        https://github.com/haskell/network/issues
@@ -41,9 +50,12 @@ description:
 
 category:           Network
 build-type:         Configure
-extra-source-files:
+
+extra-doc-files:
     README.md
     CHANGELOG.md
+
+extra-source-files:
     examples/*.hs
     tests/*.hs
     config.guess
@@ -68,7 +80,7 @@ extra-tmp-files:
 
 source-repository head
     type:     git
-    location: git://github.com/haskell/network.git
+    location: https://github.com/haskell/network.git
 
 flag devel
     description: using tests for developers


### PR DESCRIPTION
Cache reform:
- separate cache restore & save
- cache cabal store directory communicated by the setup action
- cache key per GHC and Cabal version
- always save cache

Extra CI steps:
- cabal configure (just to share build options between steps)
- cabal check
- cabal haddock

CI bumps:
- ghc 9.4
- ghc 9.6
- latest cabal

`.cabal` file fixes:
- use `extra-doc-files` section
- fix outdated git repo link syntax
- update `tested-with`

Closes #546:
- #546