### PR TITLE
Don't declare `_GNU_SOURCE` on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,9 @@ AC_INIT([Haskell network package],
         [network])
 
 dnl See also HsNet.h
-ac_includes_default="#define _GNU_SOURCE 1  /* for struct ucred on Linux */
+ac_includes_default="#ifndef _WIN32
+# define _GNU_SOURCE 1  /* for struct ucred on Linux */
+#endif
 $ac_includes_default
 
 #ifdef _WIN32

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -19,7 +19,9 @@
 # endif
 #endif
 
-#define _GNU_SOURCE 1 /* for struct ucred on Linux */
+#ifndef _WIN32
+# define _GNU_SOURCE 1 /* for struct ucred on Linux */
+#endif
 #define __APPLE_USE_RFC_3542 1 /* for IPV6_RECVPKTINFO */
 
 #ifdef _WIN32


### PR DESCRIPTION
Doing so will cause `network` to have an undeclared dependency against the `mingwex` library on Windows, which can cause issues with GHC's runtime linker. (See https://gitlab.haskell.org/ghc/ghc/-/issues/23309 for the full story.) Thankfully, there is no particular need to define `_GNU_SOURCE` on Windows in the first place, so I have guarded its definition with CPP.

Fixes #551.