### PR TITLE
Install and use `afunix_compat.h` header

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -122,8 +122,8 @@ library
 
     default-language: Haskell2010
     include-dirs:     include
-    includes:         HsNet.h HsNetDef.h alignment.h win32defs.h
-    install-includes: HsNet.h HsNetDef.h alignment.h win32defs.h
+    includes:         HsNet.h HsNetDef.h alignment.h win32defs.h afunix_compat.h
+    install-includes: HsNet.h HsNetDef.h alignment.h win32defs.h afunix_compat.h
     ghc-options:      -Wall -fwarn-tabs
     build-depends:
         base >=4.9 && <5,


### PR DESCRIPTION
We noticed in `hevm` Windows CI ([logs](https://github.com/ethereum/hevm/actions/runs/4991168529/jobs/8937297629)) that `network-bsd` started failing to build after the recent `network` release:

```text
Failed to build network-bsd-2.8.1.0.
Error: cabal-3.10.1.0.exe: Failed to build network-bsd-2.8.1.0 (which is
Build log (
required by hevm-0.51.0). See the build log above for details.
C:\cabal\logs\ghc-9.2.7\network-bsd-2.8.1.0-0a4aac5449a8d639286efd45c1dec99c4b51e487.log
):
Preprocessing library for network-bsd-2.8.1.0..

compiling dist\build\Network\BSD_hsc_make.c failed (exit code 1)
rsp file was: "dist\\build\\Network\\hsc2211.rsp"
command was: C:\ghcup\ghc\9.2.7\lib\../mingw/bin\gcc.exe -c dist\build\Network\BSD_hsc_make.c -o dist\build\Network\BSD_hsc_make.o -D__GLASGOW_HASKELL__=[902](https://github.com/ethereum/hevm/actions/runs/4991168529/jobs/8937297629#step:7:903) -Dmingw32_BUILD_OS=1 -Dx86_64_BUILD_ARCH=1 -Dmingw32_HOST_OS=1 -Dx86_64_HOST_ARCH=1 -D_WIN32_WINNT=0x0600 -Idist\build\autogen -Idist\build\global-autogen -include dist\build\autogen\cabal_macros.h -IC:\sr\ghc-9.2.7\network-3.1.3.0-b68dd294672b3c798a418a2a9ad823afe8305e69\lib\\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\time-1.11.1.1\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\bytestring-0.11.4.0\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\Win32-2.12.0.1\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\base-4.16.4.0\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\ghc-bignum-1.2\include -IC:\ghcup\ghc\9.2.7\lib\x86_64-windows-ghc-9.2.7\rts-1.0.2\include
error: In file included from BSD.hsc:32:
C:/sr/ghc-9.2.7/network-3.1.3.0-b68dd294672b3c798a418a2a9ad823afe8305e69/lib/include/HsNet.h:32:11: fatal error: afunix_compat.h: No such file or directory
   32 | # include "afunix_compat.h"
      |           ^~~~~~~~~~~~~~~~~
compilation terminated.
```

This appears to be due to `network` not exposing the new `afunix_compat.h` to dependencies. This PR adds the header to `includes` and `install-includes` which resolves the build failure.