### PR TITLE
Allow a control message to contain multiple file descriptors (issue #566)

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -245,13 +245,11 @@ module Network.Socket
             ,CmsgIdIPv6TClass
             ,CmsgIdIPv4PktInfo
             ,CmsgIdIPv6PktInfo
-            ,CmsgIdFd
+            ,CmsgIdFds
             ,UnsupportedCmsgId)
     -- ** APIs for control message
     , lookupCmsg
     , filterCmsg
-    , decodeCmsg
-    , encodeCmsg
     -- ** Class and types for control message
     , ControlMessage(..)
     , IPv4TTL(..)

--- a/Network/Socket/ByteString/IO.hsc
+++ b/Network/Socket/ByteString/IO.hsc
@@ -231,7 +231,7 @@ sendManyWithFds s bss fds =
             sendBufMsg s addr bufsizs cmsgs flags
   where
     addr = NullSockAddr
-    cmsgs = encodeCmsg <$> fds
+    cmsgs = encodeCmsg . (:[]) <$> fds
     flags = mempty
 
 -- ----------------------------------------------------------------------------

--- a/Network/Socket/Unix.hsc
+++ b/Network/Socket/Unix.hsc
@@ -137,7 +137,7 @@ isUnixDomainSocketAvailable = True
 --   This function does not work on Windows.
 sendFd :: Socket -> CInt -> IO ()
 sendFd s outfd = void $ allocaBytes dummyBufSize $ \buf -> do
-    let cmsg = encodeCmsg $ Fd outfd
+    let cmsg = encodeCmsg [Fd outfd]
     sendBufMsg s NullSockAddr [(buf,dummyBufSize)] [cmsg] mempty
   where
     dummyBufSize = 1
@@ -149,9 +149,9 @@ sendFd s outfd = void $ allocaBytes dummyBufSize $ \buf -> do
 recvFd :: Socket -> IO CInt
 recvFd s = allocaBytes dummyBufSize $ \buf -> do
     (NullSockAddr, _, cmsgs, _) <- recvBufMsg s [(buf,dummyBufSize)] 32 mempty
-    case (lookupCmsg CmsgIdFd cmsgs >>= decodeCmsg) :: Maybe Fd of
-      Nothing      -> return (-1)
-      Just (Fd fd) -> return fd
+    case (lookupCmsg CmsgIdFds cmsgs >>= decodeCmsg) :: Maybe [Fd] of
+      Just (Fd fd : _) -> return fd
+      _                -> return (-1)
   where
     dummyBufSize = 16
 

--- a/tests/Network/SocketSpec.hs
+++ b/tests/Network/SocketSpec.hs
@@ -14,6 +14,7 @@ import Network.Test.Common
 import System.Mem (performGC)
 import System.IO.Error (tryIOError)
 import System.IO.Temp (withSystemTempDirectory)
+import System.Posix.Types (Fd(..))
 import Foreign.C.Types ()
 
 import Test.Hspec
@@ -378,6 +379,10 @@ spec = do
             let msgid = CmsgId (-300) (-300) in
             show msgid `shouldBe` "CmsgId (-300) (-300)"
 
+    describe "bijective encodeCmsg-decodeCmsg roundtrip equality" $ do
+        it "holds for [Fd]" $ forAll genFds $
+            \x -> (decodeCmsg . encodeCmsg $ x) == Just (x :: [Fd])
+
     describe "bijective read-show roundtrip equality" $ do
         it "holds for Family" $ forAll familyGen $
             \x -> (read . show $ x) == (x :: Family)
@@ -414,6 +419,9 @@ sockoptGen = biasedGen (\g -> SockOpt <$> g <*> g) sockoptPatterns arbitrary
 
 cmsgidGen :: Gen CmsgId
 cmsgidGen = biasedGen (\g -> CmsgId <$> g <*> g) cmsgidPatterns arbitrary
+
+genFds :: Gen [Fd]
+genFds = listOf (Fd <$> arbitrary)
 
 -- pruned lists of pattern synonym values for each type to generate values from
 
@@ -462,5 +470,5 @@ cmsgidPatterns = nub
     , CmsgIdIPv6TClass
     , CmsgIdIPv4PktInfo
     , CmsgIdIPv6PktInfo
-    , CmsgIdFd
+    , CmsgIdFds
     ]


### PR DESCRIPTION
ControlMessage has lost the Storable constraint, because it is not possible to implement Storable [Fd] because [Fd] is not fixed-size when encoded.