### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/network.cabal
+++ b/network.cabal
@@ -125,7 +125,6 @@ library
     include-dirs:     include
     install-includes: HsNet.h HsNetDef.h alignment.h win32defs.h
     if os(windows)
-        includes:         afunix_compat.h
         install-includes: afunix_compat.h
 
     ghc-options:      -Wall -fwarn-tabs

--- a/network.cabal
+++ b/network.cabal
@@ -123,7 +123,6 @@ library
 
     default-language: Haskell2010
     include-dirs:     include
-    includes:         HsNet.h HsNetDef.h alignment.h win32defs.h
     install-includes: HsNet.h HsNetDef.h alignment.h win32defs.h
     if os(windows)
         includes:         afunix_compat.h


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355