### PR TITLE
Add `SockOptValue` and `setSockOptValue`

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -181,6 +181,8 @@ module Network.Socket (
     setSocketOption,
     getSockOpt,
     setSockOpt,
+    SockOptValue (..),
+    setSockOptValue,
 
     -- * Socket
     Socket,


### PR DESCRIPTION
The motivation for this is to enable an interface in `network-run` similar to the `open{Client,Server,TCPServer}SocketWithOptions` that allows users to set multiple socket option values of potentially different value types, e.g. `NoDelay` and `Linger`. See the [corresponding PR in `network-run`](https://github.com/kazu-yamamoto/network-run/pull/12)