### PR TITLE
Add macos-13 to the CI matrix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:  [ 'ubuntu-latest', 'macOS-latest', 'windows-latest' ]
+        os:  [ 'ubuntu-latest', 'macOS-latest', 'macos-13', 'windows-latest' ]
         ghc: [ '9.4', '9.6', '9.8' ]
 
     steps:


### PR DESCRIPTION
Hoping to help diagnose #594. Macos-13 is x86_64 architecture and so I suspect has different native libraries that are causing the issue.