### PR TITLE
Support Wasm/WASI

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -176,7 +176,9 @@ module Network.Socket (
     setSocketOption,
 
     -- ** General socket options
+#ifdef SO_LINGER
     StructLinger (..),
+#endif
     SocketTimeout (..),
     getSockOpt,
     setSockOpt,

--- a/Network/Socket/Buffer.hsc
+++ b/Network/Socket/Buffer.hsc
@@ -57,6 +57,7 @@ sendBufTo :: SocketAddress sa =>
           -> Int         -- Data to send
           -> sa
           -> IO Int      -- Number of Bytes sent
+#ifdef HAVE_SENDTO
 sendBufTo s ptr nbytes sa =
   withSocketAddress sa $ \p_sa siz -> fromIntegral <$> do
     withFdSocket s $ \fd -> do
@@ -65,6 +66,10 @@ sendBufTo s ptr nbytes sa =
             flags = 0
         throwSocketErrorWaitWrite s "Network.Socket.sendBufTo" $
           c_sendto fd ptr n flags p_sa sz
+#else
+sendBufTo _ _ _ _ = unsupported "sendBufTo"
+{-# WARNING sendBufTo "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 #if defined(mingw32_HOST_OS)
 socket2FD :: Socket -> IO FD
@@ -112,6 +117,7 @@ sendBuf s str len = fromIntegral <$> do
 -- NOTE: blocking on Windows unless you compile with -threaded (see
 -- GHC ticket #1129)
 recvBufFrom :: SocketAddress sa => Socket -> Ptr a -> Int -> IO (Int, sa)
+#ifdef HAVE_RECVFROM
 recvBufFrom s ptr nbytes
     | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBufFrom")
     | otherwise = withNewSocketAddress $ \ptr_sa sz -> alloca $ \ptr_len ->
@@ -124,6 +130,10 @@ recvBufFrom s ptr nbytes
             sockaddr <- peekSocketAddress ptr_sa
                 `catchIOError` \_ -> getPeerName s
             return (fromIntegral len, sockaddr)
+#else
+recvBufFrom _ _ _ = unsupported "recvBufFrom"
+{-# WARNING recvBufFrom "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 -- | Receive data from the socket.  The socket must be in a connected
 -- state. This function may return fewer bytes than specified.  If the
@@ -204,6 +214,7 @@ sendBufMsg :: SocketAddress sa
            -> [Cmsg]            -- ^ Control messages
            -> MsgFlag           -- ^ Message flags
            -> IO Int            -- ^ The length actually sent
+#ifdef HAVE_STRUCT_CMSGHDR
 sendBufMsg s sa bufsizs cmsgs flags = do
   sz <- withSocketAddress sa $ \addrPtr addrSize ->
 #if !defined(mingw32_HOST_OS)
@@ -237,6 +248,10 @@ sendBufMsg s sa bufsizs cmsgs flags = do
                 c_sendmsg fd msgHdrPtr (fromIntegral cflags) send_ptr nullPtr nullPtr
 #endif
   return $ fromIntegral sz
+#else
+sendBufMsg _ _ _ _ _ = unsupported "sendBufMsg"
+{-# WARNING sendBufMsg "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 -- | Receive data from the socket using recvmsg(2). The supplied
 --   buffers are filled in order, with subsequent buffers used only
@@ -252,6 +267,7 @@ recvBufMsg :: SocketAddress sa
                                 --   'MSG_CTRUNC' is returned
            -> MsgFlag           -- ^ Message flags
            -> IO (sa,Int,[Cmsg],MsgFlag) -- ^ Source address, total bytes received, control messages and message flags
+#ifdef HAVE_STRUCT_CMSGHDR
 recvBufMsg s bufsizs clen flags = do
   withNewSocketAddress $ \addrPtr addrSize ->
     allocaBytes clen $ \ctrlPtr ->
@@ -295,6 +311,10 @@ recvBufMsg s bufsizs clen flags = do
             cmsgs <- parseCmsgs msgHdrPtr
             let flags' = MsgFlag $ fromIntegral $ msgFlags hdr
             return (sockaddr, len, cmsgs, flags')
+#else
+recvBufMsg _ _ _ _ = unsupported "recvBufMsg"
+{-# WARNING recvBufMsg "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 #if !defined(mingw32_HOST_OS)
 foreign import ccall unsafe "send"
@@ -317,8 +337,11 @@ foreign import CALLCONV SAFE_ON_WIN "WSARecvMsg"
 
 foreign import ccall unsafe "recv"
   c_recv :: CInt -> Ptr CChar -> CSize -> CInt -> IO CInt
+#ifdef HAVE_SENDTO
 foreign import CALLCONV SAFE_ON_WIN "sendto"
   c_sendto :: CInt -> Ptr a -> CSize -> CInt -> Ptr sa -> CInt -> IO CInt
+#endif
+#ifdef HAVE_RECVFROM
 foreign import CALLCONV SAFE_ON_WIN "recvfrom"
   c_recvfrom :: CInt -> Ptr a -> CSize -> CInt -> Ptr sa -> Ptr CInt -> IO CInt
-
+#endif

--- a/Network/Socket/Cbits.hsc
+++ b/Network/Socket/Cbits.hsc
@@ -7,8 +7,14 @@ import Network.Socket.Imports
 -- | This is the value of SOMAXCONN, typically 128.
 -- 128 is good enough for normal network servers but
 -- is too small for high performance servers.
+--
+-- TODO what if not present
 maxListenQueue :: Int
+#ifdef SOMAXCONN
 maxListenQueue = #const SOMAXCONN
+#else
+maxListenQueue = 1
+#endif
 
 #if defined(mingw32_HOST_OS)
 wsaNotInitialized :: CInt

--- a/Network/Socket/If.hs
+++ b/Network/Socket/If.hs
@@ -10,29 +10,44 @@ module Network.Socket.If (
 import Foreign.Marshal.Alloc (allocaBytes)
 
 import Network.Socket.Imports
+import Network.Socket.Internal (unsupported)
 
 -- | Returns the index corresponding to the interface name.
 --
 --   Since 2.7.0.0.
 ifNameToIndex :: String -> IO (Maybe Int)
+#ifdef HAVE_IF_NAMETOINDEX
 ifNameToIndex ifname = do
   index <- withCString ifname c_if_nametoindex
   -- On failure zero is returned. We'll return Nothing.
   return $ if index == 0 then Nothing else Just $ fromIntegral index
+#else
+ifNameToIndex _ = unsupported "ifNameToIndex"
+{-# WARNING ifNameToIndex "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 -- | Returns the interface name corresponding to the index.
 --
 --   Since 2.7.0.0.
 ifIndexToName :: Int -> IO (Maybe String)
+#ifdef HAVE_IF_INDEXTONAME
 ifIndexToName ifn = allocaBytes 16 $ \ptr -> do -- 16 == IFNAMSIZ
     r <- c_if_indextoname (fromIntegral ifn) ptr
     if r == nullPtr then
         return Nothing
       else
         Just <$> peekCString ptr
+#else
+ifIndexToName _ = unsupported "ifIndexToName"
+{-# WARNING ifIndexToName "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
+#ifdef HAVE_IF_NAMETOINDEX
 foreign import CALLCONV safe "if_nametoindex"
    c_if_nametoindex :: CString -> IO CUInt
+#endif
 
+#ifdef HAVE_IF_INDEXTONAME
 foreign import CALLCONV safe "if_indextoname"
    c_if_indextoname :: CUInt -> CString -> IO CString
+#endif

--- a/Network/Socket/Internal.hs
+++ b/Network/Socket/Internal.hs
@@ -51,6 +51,9 @@ module Network.Socket.Internal
     -- * Null socket address type
     , NullSockAddr (..)
 
+    -- * Unsupported functionality
+    , unsupported
+
     -- * Low-level helpers
     , zeroMemory
     ) where

--- a/Network/Socket/Name.hs
+++ b/Network/Socket/Name.hs
@@ -17,6 +17,7 @@ import Network.Socket.Types
 
 -- | Getting peer's socket address.
 getPeerName :: SocketAddress sa => Socket -> IO sa
+#ifdef HAVE_GETPEERNAME
 getPeerName s =
  withNewSocketAddress $ \ptr sz ->
    with (fromIntegral sz) $ \int_star -> withFdSocket s $ \fd -> do
@@ -24,6 +25,10 @@ getPeerName s =
        c_getpeername fd ptr int_star
      _sz <- peek int_star
      peekSocketAddress ptr
+#else
+getPeerName _ = unsupported "getPeerName"
+{-# WARNING getPeerName "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 
 -- | Getting my socket address.
 getSocketName :: SocketAddress sa => Socket -> IO sa
@@ -34,8 +39,10 @@ getSocketName s =
        c_getsockname fd ptr int_star
      peekSocketAddress ptr
 
+#ifdef HAVE_GETPEERNAME
 foreign import CALLCONV unsafe "getpeername"
   c_getpeername :: CInt -> Ptr sa -> Ptr CInt -> IO CInt
+#endif
 foreign import CALLCONV unsafe "getsockname"
   c_getsockname :: CInt -> Ptr sa -> Ptr CInt -> IO CInt
 

--- a/Network/Socket/Posix/Cmsg.hsc
+++ b/Network/Socket/Posix/Cmsg.hsc
@@ -86,7 +86,11 @@ pattern CmsgIdIPv6PktInfo = CmsgId (-1) (-1)
 
 -- | The identifier for 'Fds'.
 pattern CmsgIdFds :: CmsgId
+#if defined(SCM_RIGHTS)
 pattern CmsgIdFds = CmsgId (#const SOL_SOCKET) (#const SCM_RIGHTS)
+#else
+pattern CmsgIdFds = CmsgId (-1) (-1)
+#endif
 
 ----------------------------------------------------------------
 

--- a/Network/Socket/Posix/CmsgHdr.hsc
+++ b/Network/Socket/Posix/CmsgHdr.hsc
@@ -4,8 +4,10 @@
 
 module Network.Socket.Posix.CmsgHdr (
     Cmsg(..)
+#ifdef HAVE_STRUCT_CMSGHDR
   , withCmsgs
   , parseCmsgs
+#endif
   ) where
 
 #include <sys/types.h>
@@ -21,6 +23,8 @@ import Network.Socket.Imports
 import Network.Socket.Posix.Cmsg
 import Network.Socket.Posix.MsgHdr
 import Network.Socket.Types
+
+#ifdef HAVE_STRUCT_CMSGHDR
 
 data CmsgHdr = CmsgHdr {
 #ifdef __linux__
@@ -105,3 +109,5 @@ foreign import ccall unsafe "cmsg_space"
 
 foreign import ccall unsafe "cmsg_len"
   c_cmsg_len :: CSize -> CSize
+
+#endif

--- a/Network/Socket/Unix.hsc
+++ b/Network/Socket/Unix.hsc
@@ -177,6 +177,7 @@ socketPair _ _ _ = withSystemTempFile "temp-for-pair" $ \file hdl -> do
     withFdSocket serverSock setNonBlockIfNeeded
     return (clientSock, serverSock)
 #else
+#if HAVE_SOCKETPAIR
 socketPair family stype protocol =
     allocaBytes (2 * sizeOf (1 :: CInt)) $ \ fdArr -> do
       let c_stype = packSocketType stype
@@ -191,4 +192,8 @@ socketPair family stype protocol =
 
 foreign import ccall unsafe "socketpair"
   c_socketpair :: CInt -> CInt -> CInt -> Ptr CInt -> IO CInt
+#else
+socketPair _ _ _ = unsupported "socketPair"
+{-# WARNING socketPair "operation will throw 'IOError' \"unsupported operation\"" #-}
+#endif
 #endif

--- a/cbits/cmsg.c
+++ b/cbits/cmsg.c
@@ -75,6 +75,7 @@ WSARecvMsg (SOCKET s, LPWSAMSG lpMsg, LPDWORD lpdwNumberOfBytesRecvd,
   return res;
 }
 #else
+#ifdef HAVE_STRUCT_CMSGHDR
 struct cmsghdr *cmsg_firsthdr(struct msghdr *mhdr) {
   return (CMSG_FIRSTHDR(mhdr));
 }
@@ -94,4 +95,5 @@ size_t cmsg_space(size_t l) {
 size_t cmsg_len(size_t l) {
   return (CMSG_LEN(l));
 }
+#endif
 #endif /* _WIN32 */

--- a/configure.ac
+++ b/configure.ac
@@ -77,18 +77,28 @@ AC_CHECK_HEADERS([sys/uio.h sys/socket.h netinet/in.h netinet/tcp.h])
 AC_CHECK_HEADERS([sys/un.h arpa/inet.h netdb.h])
 AC_CHECK_HEADERS([net/if.h netioapi.h])
 
-AC_CHECK_TYPES([struct ucred])
+AC_CHECK_TYPES([struct ucred, struct addrinfo, struct cmsghdr])
 
 AC_CHECK_FUNCS([gai_strerror gethostent accept4])
 AC_CHECK_FUNCS([getpeereid])
+AC_CHECK_FUNCS([getnameinfo getaddrinfo])
+AC_CHECK_FUNCS([socket, bind, connect, listen])
+AC_CHECK_FUNCS([sendto, recvfrom])
+AC_CHECK_FUNCS([setsockopt])
+AC_CHECK_FUNCS([if_nametoindex, if_indextoname])
+AC_CHECK_FUNCS([getpeername])
+AC_CHECK_FUNCS([socketpair])
+AC_CHECK_FUNCS([dup])
 
-AC_CHECK_DECLS([AI_ADDRCONFIG, AI_ALL, AI_NUMERICSERV, AI_V4MAPPED])
+AC_CHECK_DECLS([AI_ADDRCONFIG, AI_ALL, AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV, AI_PASSIVE, AI_V4MAPPED])
+AC_CHECK_DECLS([NI_DGRAM, NI_NAMEREQD, NI_NOFQDN, NI_NUMERICHOST, NI_NUMERICSERV])
 AC_CHECK_DECLS([IPV6_V6ONLY])
 AC_CHECK_DECLS([IPPROTO_IP, IPPROTO_TCP, IPPROTO_IPV6])
 AC_CHECK_DECLS([SO_PEERCRED])
 
 AC_CHECK_MEMBERS([struct msghdr.msg_control, struct msghdr.msg_accrights])
 AC_CHECK_MEMBERS([struct sockaddr.sa_len])
+AC_CHECK_MEMBERS([struct sockaddr_un.sun_path])
 
 dnl This is a necessary hack
 AC_MSG_NOTICE([creating ./network.buildinfo])

--- a/include/HsNet.h
+++ b/include/HsNet.h
@@ -120,6 +120,7 @@ sendFd(int sock, int outfd);
 extern int
 recvFd(int sock);
 
+#ifdef HAVE_STRUCT_CMSGHDR
 extern struct cmsghdr *
 cmsg_firsthdr(struct msghdr *mhdr);
 
@@ -134,8 +135,10 @@ cmsg_space(size_t l);
 
 extern size_t
 cmsg_len(size_t l);
+#endif
 #endif /* _WIN32 */
 
+#if HAVE_GETNAMEINFO
 INLINE int
 hsnet_getnameinfo(const struct sockaddr* a,socklen_t b, char* c,
 # if defined(_WIN32)
@@ -146,7 +149,9 @@ hsnet_getnameinfo(const struct sockaddr* a,socklen_t b, char* c,
 {
   return getnameinfo(a,b,c,d,e,f,g);
 }
+#endif
 
+#if HAVE_GETADDRINFO
 INLINE int
 hsnet_getaddrinfo(const char *hostname, const char *servname,
 		  const struct addrinfo *hints, struct addrinfo **res)
@@ -159,6 +164,7 @@ hsnet_freeaddrinfo(struct addrinfo *ai)
 {
     freeaddrinfo(ai);
 }
+#endif
 
 #ifndef IOV_MAX
 # define IOV_MAX 1024


### PR DESCRIPTION
TL;DR if you want to use this to get your Wasm project to compile:

```cabal
source-repository-package
  type: git
  location: https://github.com/haskell-wasm/network
  tag: ed252fbf8b98bd5724fbc71e23eb5f8ab4305381
```
(This is pointing to a branch where the configure script has been checked in.)

---

This PR adds a bunch of CPP in order to build with the GHC Wasm backend. However, nothing here is actually really Wasm-specific (e.g. the diff doesn't mention Wasm); there could be other platforms that are also missing certain network functionality similar to Wasm.

This PR probably shouldn't be merged as is; it probably makes sense to wait at least until the Wasm backend updates to WASI preview2 which seems to support more networking stuff.

For a simple example how networking stuff works with Wasm today, see https://gist.github.com/amesgen/8b7d6dc672e7818d951142afa1263dde for a simple echo server example, which can be run via
```console
wasmtime run -S preview2=n -S tcplisten=127.0.0.1:12345 /path/to/wasi-echo-server.wasm
```
and interacted with via e.g. `nc 127.0.0.1 12345`.

However, usually, `network` is just an accidental dependency in projects that don't actually do any networking stuff (e.g. because they depend on `streaming-commons` somehow). Still, it is useful to have something that compiles on Wasm as one has to patch fewer dependencies this way.