### PR TITLE
Fix `UserTimeout` on macos

### DIFF
--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -299,6 +299,8 @@ pattern NoDelay        = SockOpt (-1) (-1)
 pattern UserTimeout :: SocketOption
 #ifdef TCP_USER_TIMEOUT
 pattern UserTimeout    = SockOpt (#const IPPROTO_TCP) (#const TCP_USER_TIMEOUT)
+#elif defined(TCP_CONNECTIONTIMEOUT)
+pattern UserTimeout    = SockOpt (#const IPPROTO_TCP) (#const TCP_CONNECTIONTIMEOUT)
 #else
 pattern UserTimeout    = SockOpt (-1) (-1)
 #endif


### PR DESCRIPTION
Uses [`TCP_CONNECTIONTIMEOUT`](https://keith.github.io/xcode-man-pages/tcp.4.html#TCP_CONNECTIONTIMEOUT) if `TCP_USER_TIMEOUT` cannot be found.