### PR TITLE
Add experimental WinIO support

### DIFF
--- a/Network/Socket/Buffer.hs
+++ b/Network/Socket/Buffer.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE CPP #-}
+
+#include "HsNetDef.h"
+
+module Network.Socket.Buffer (
+    sendBufTo
+  , sendBuf
+  , recvBufFrom
+  , recvBuf
+  , recvBufNoWait
+  , sendBufMsg
+  , recvBufMsg
+  ) where
+
+import Network.Socket.Imports
+import Network.Socket.Types
+import Network.Socket.Flag
+
+#if defined(mingw32_HOST_OS)
+import Network.Socket.Win32.CmsgHdr
+#else
+import Network.Socket.Posix.CmsgHdr
+#endif
+
+import qualified Network.Socket.Buffer.Posix as Posix
+#if defined(mingw32_HOST_OS)
+import qualified Network.Socket.Buffer.WinIO as Win
+#endif
+
+sendBufTo :: SocketAddress sa => Socket -> Ptr a -> Int -> sa -> IO Int
+#if defined(mingw32_HOST_OS)
+sendBufTo = eitherSocket Posix.sendBufTo Win.sendBufTo
+#else
+sendBufTo = Posix.sendBufTo
+#endif
+
+sendBuf :: Socket -> Ptr Word8 -> Int -> IO Int
+#if defined(mingw32_HOST_OS)
+sendBuf = eitherSocket Posix.sendBuf Win.sendBuf
+#else
+sendBuf = Posix.sendBuf
+#endif
+
+recvBufFrom :: SocketAddress sa => Socket -> Ptr a -> Int -> IO (Int, sa)
+#if defined(mingw32_HOST_OS)
+recvBufFrom = eitherSocket Posix.recvBufFrom Win.recvBufFrom
+#else
+recvBufFrom = Posix.recvBufFrom
+#endif
+
+recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
+#if defined(mingw32_HOST_OS)
+recvBuf = eitherSocket Posix.recvBuf Win.recvBuf
+#else
+recvBuf = Posix.recvBuf
+#endif
+
+recvBufNoWait :: Socket -> Ptr Word8 -> Int -> IO Int
+#if defined(mingw32_HOST_OS)
+recvBufNoWait = eitherSocket Posix.recvBufNoWait Win.recvBufNoWait
+#else
+recvBufNoWait = Posix.recvBufNoWait
+#endif
+
+sendBufMsg :: SocketAddress sa
+           => Socket -> sa -> [(Ptr Word8,Int)] -> [Cmsg] -> MsgFlag -> IO Int
+#if defined(mingw32_HOST_OS)
+sendBufMsg = eitherSocket Posix.sendBufMsg Win.sendBufMsg
+#else
+sendBufMsg = Posix.sendBufMsg
+#endif
+
+recvBufMsg :: SocketAddress sa
+           => Socket -> [(Ptr Word8,Int)] -> Int -> MsgFlag
+           -> IO (sa,Int,[Cmsg],MsgFlag)
+#if defined(mingw32_HOST_OS)
+recvBufMsg = eitherSocket Posix.recvBufMsg Win.recvBufMsg
+#else
+recvBufMsg = Posix.recvBufMsg
+#endif

--- a/Network/Socket/Buffer/Posix.hsc
+++ b/Network/Socket/Buffer/Posix.hsc
@@ -5,7 +5,7 @@
 #  include "windows.h"
 #endif
 
-module Network.Socket.Buffer (
+module Network.Socket.Buffer.Posix (
     sendBufTo
   , sendBuf
   , recvBufFrom
@@ -17,8 +17,6 @@ module Network.Socket.Buffer (
 
 #if !defined(mingw32_HOST_OS)
 import Foreign.C.Error (getErrno, eAGAIN, eWOULDBLOCK)
-#else
-import Foreign.Ptr (nullPtr)
 #endif
 import Foreign.Marshal.Alloc (alloca, allocaBytes)
 import Foreign.Marshal.Utils (with)
@@ -27,6 +25,7 @@ import System.IO.Error (mkIOError, ioeSetErrorString, catchIOError)
 
 #if defined(mingw32_HOST_OS)
 import GHC.IO.FD (FD(..), readRawBufferPtr, writeRawBufferPtr)
+import qualified Network.Socket.Types as Generic
 import Network.Socket.Win32.CmsgHdr
 import Network.Socket.Win32.MsgHdr
 import Network.Socket.Win32.WSABuf
@@ -37,14 +36,42 @@ import Network.Socket.Posix.IOVec
 #endif
 
 import Network.Socket.Imports
+#if defined(mingw32_HOST_OS)
+import Network.Socket.Internal hiding (throwSocketErrorWaitRead, throwSocketErrorWaitWrite, throwSocketErrorWaitReadBut)
+#else
 import Network.Socket.Internal
-import Network.Socket.Name
-import Network.Socket.Types
+#endif
+import Network.Socket.Name (getPeerName)
+import Network.Socket.Types (
+    SocketAddress,
+    withSocketAddress,
+    withNewSocketAddress,
+    peekSocketAddress,
+    )
+import Network.Socket.Types.Posix
 import Network.Socket.Flag
 
 #if defined(mingw32_HOST_OS)
 type DWORD   = Word32
 type LPDWORD = Ptr DWORD
+
+-- On Windows, threadWaitRead is a no-op, so don't sweat wrapping Posix.Socket -> generic Socket.
+throwSocketErrorWaitRead :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+throwSocketErrorWaitRead _ = throwSocketErrorIfMinus1Retry
+
+throwSocketErrorWaitWrite :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+throwSocketErrorWaitWrite _ = throwSocketErrorIfMinus1Retry
+
+throwSocketErrorWaitReadBut :: (Eq a, Num a) => (CInt -> Bool) -> Socket -> String -> IO a -> IO a
+throwSocketErrorWaitReadBut exempt _ = throwSocketErrorIfMinus1ButRetry exempt
+
+-- getPeerName takes the generic Socket; wrap our Posix.Socket.
+getPeerName' :: SocketAddress sa => Socket -> IO sa
+getPeerName' s = getPeerName (Generic.Socket (Left s))
+#else
+-- On non-Windows, Socket = Posix.Socket, so the generic versions work.
+getPeerName' :: SocketAddress sa => Socket -> IO sa
+getPeerName' = getPeerName
 #endif
 
 -- | Send data to the socket.  The recipient can be specified
@@ -122,7 +149,7 @@ recvBufFrom s ptr nbytes
             len <- throwSocketErrorWaitRead s "Network.Socket.recvBufFrom" $
                      c_recvfrom fd ptr cnbytes flags ptr_sa ptr_len
             sockaddr <- peekSocketAddress ptr_sa
-                `catchIOError` \_ -> getPeerName s
+                `catchIOError` \_ -> getPeerName' s
             return (fromIntegral len, sockaddr)
 
 -- | Receive data from the socket.  The socket must be in a connected
@@ -290,11 +317,11 @@ recvBufMsg s bufsizs clen flags = do
                             c_recvmsg fd msgHdrPtr len_ptr nullPtr nullPtr
                     peek len_ptr
 #endif
-            sockaddr <- peekSocketAddress addrPtr `catchIOError` \_ -> getPeerName s
+            sockaddr <- peekSocketAddress addrPtr `catchIOError` \_ -> getPeerName' s
             hdr <- peek msgHdrPtr
-            cmsgs <- parseCmsgs msgHdrPtr
+            cmsgs' <- parseCmsgs msgHdrPtr
             let flags' = MsgFlag $ fromIntegral $ msgFlags hdr
-            return (sockaddr, len, cmsgs, flags')
+            return (sockaddr, len, cmsgs', flags')
 
 #if !defined(mingw32_HOST_OS)
 foreign import ccall unsafe "send"
@@ -321,4 +348,3 @@ foreign import CALLCONV SAFE_ON_WIN "sendto"
   c_sendto :: CInt -> Ptr a -> CSize -> CInt -> Ptr sa -> CInt -> IO CInt
 foreign import CALLCONV SAFE_ON_WIN "recvfrom"
   c_recvfrom :: CInt -> Ptr a -> CSize -> CInt -> Ptr sa -> Ptr CInt -> IO CInt
-

--- a/Network/Socket/Buffer/WinIO.hsc
+++ b/Network/Socket/Buffer/WinIO.hsc
@@ -1,0 +1,323 @@
+{-# LANGUAGE CPP #-}
+module Network.Socket.Buffer.WinIO (
+    sendBuf,
+    sendBufTo,
+    recvBuf,
+    recvBufFrom,
+    recvBufNoWait,
+    sendBufMsg,
+    recvBufMsg,
+) where
+
+#include "HsNet.h"
+##include "HsNetDef.h"
+
+import Control.Concurrent.STM
+import Foreign.Marshal.Utils (with)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import GHC.Event.Windows
+import GHC.IO.Exception (IOErrorType(InvalidArgument))
+import GHC.Windows
+import Network.Socket.Imports
+import Network.Socket.Internal
+import Network.Socket.Name (getPeerName)
+import Network.Socket.Types (SocketAddress, withSocketAddress, withNewSocketAddress, peekSocketAddress)
+import qualified Network.Socket.Types as Generic
+import Network.Socket.Types.WinIO
+import Network.Socket.Flag
+import Network.Socket.Win32.CmsgHdr
+import Network.Socket.Win32.MsgHdr
+import Network.Socket.Win32.WSABuf (WSABuf(..), withWSABuf)
+import Network.Socket.Win32.Load
+import System.IO.Error (mkIOError, ioeSetErrorString, catchIOError)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- | Extract the byte count from a completed overlapped I/O result.
+ioBytes :: IOResult DWORD -> Int
+ioBytes = fromIntegral . ioValue
+
+sendBuf :: Socket -> Ptr Word8 -> Int -> IO Int
+sendBuf s ptr len = withSOCKET s $ \sock ->
+    with (WSABuf ptr (fromIntegral len)) $ \wbuf ->
+        ioBytes <$> withOverlapped "Network.Socket.sendBuf" sock 0
+            (\lpOverlapped -> do
+                ret <- c_WSASend sock wbuf 1 nullPtr 0 lpOverlapped nullPtr
+                if ret == 0
+                    then pure CbPending
+                    else do
+                        le <- c_getLastError
+                        pure $ if le == #{const ERROR_IO_PENDING}
+                            then CbPending
+                            else CbError (fromIntegral le)
+            )
+            (\errCode numBytes -> case errCode of
+                0 -> ioSuccess numBytes
+                _ -> ioFailed $ ntStatusToDosError errCode
+            )
+
+sendBufTo :: SocketAddress sa => Socket -> Ptr a -> Int -> sa -> IO Int
+sendBufTo s ptr nbytes sa =
+    withSocketAddress sa $ \p_sa siz ->
+      withSOCKET s $ \sock ->
+        with (WSABuf (castPtr ptr) (fromIntegral nbytes)) $ \wbuf ->
+            ioBytes <$> withOverlapped "Network.Socket.sendBufTo" sock 0
+                (\lpOverlapped -> do
+                    ret <- c_WSASendTo sock wbuf 1 nullPtr 0
+                               p_sa (fromIntegral siz) lpOverlapped nullPtr
+                    if ret == 0
+                        then pure CbPending
+                        else do
+                            le <- c_getLastError
+                            pure $ if le == #{const ERROR_IO_PENDING}
+                                then CbPending
+                                else CbError (fromIntegral le)
+                )
+                (\errCode numBytes -> case errCode of
+                    0 -> ioSuccess numBytes
+                    _ -> ioFailed $ ntStatusToDosError errCode
+                )
+
+recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
+recvBuf s ptr nbytes
+    | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBuf")
+    | otherwise = withSOCKET s $ \sock ->
+        with (WSABuf ptr (fromIntegral nbytes)) $ \wbuf ->
+          alloca $ \flagsPtr -> do
+            poke flagsPtr (0 :: DWORD)
+            ioBytes <$> withOverlapped "Network.Socket.recvBuf" sock 0
+                (\lpOverlapped -> do
+                    ret <- c_WSARecv sock wbuf 1 nullPtr flagsPtr lpOverlapped nullPtr
+                    if ret == 0
+                        then pure CbPending
+                        else do
+                            le <- c_getLastError
+                            pure $ if le == #{const ERROR_IO_PENDING}
+                                then CbPending
+                                else CbError (fromIntegral le)
+                )
+                (\errCode numBytes -> case errCode of
+                    0 -> ioSuccess numBytes
+                    _ -> ioFailed $ ntStatusToDosError errCode
+                )
+
+recvBufFrom :: SocketAddress sa => Socket -> Ptr a -> Int -> IO (Int, sa)
+recvBufFrom s ptr nbytes
+    | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBufFrom")
+    | otherwise = withNewSocketAddress $ \ptr_sa sz ->
+        alloca $ \ptr_len ->
+          withSOCKET s $ \sock ->
+            with (WSABuf (castPtr ptr) (fromIntegral nbytes)) $ \wbuf ->
+              alloca $ \flagsPtr -> do
+                poke ptr_len (fromIntegral sz)
+                poke flagsPtr (0 :: DWORD)
+                len <- ioBytes <$> withOverlapped "Network.Socket.recvBufFrom" sock 0
+                    (\lpOverlapped -> do
+                        ret <- c_WSARecvFrom sock wbuf 1 nullPtr flagsPtr
+                                   ptr_sa ptr_len lpOverlapped nullPtr
+                        if ret == 0
+                            then pure CbPending
+                            else do
+                                le <- c_getLastError
+                                pure $ if le == #{const ERROR_IO_PENDING}
+                                    then CbPending
+                                    else CbError (fromIntegral le)
+                    )
+                    (\errCode numBytes -> case errCode of
+                        0 -> ioSuccess numBytes
+                        _ -> ioFailed $ ntStatusToDosError errCode
+                    )
+                sockaddr <- peekSocketAddress ptr_sa
+                    `catchIOError` \_ -> getPeerName (Generic.Socket (Right s))
+                return (len, sockaddr)
+
+recvBufNoWait :: Socket -> Ptr Word8 -> Int -> IO Int
+recvBufNoWait s ptr nbytes = withFdSocket s $ \fd ->
+    alloca $ \ptr_bytes -> do
+      res <- c_ioctlsocket fd #{const FIONREAD} ptr_bytes
+      avail <- peek ptr_bytes
+      r <- if res == #{const NO_ERROR} && avail > 0 then
+               c_recv fd (castPtr ptr) (fromIntegral nbytes) 0{-flags-}
+           else if avail == 0 then
+               return (-1)
+           else do err <- c_WSAGetLastError
+                   if err == #{const WSAEWOULDBLOCK}
+                       || err == #{const WSAEINPROGRESS} then
+                       return (-1)
+                     else
+                        return (-2)
+      return $ fromIntegral r
+
+-- | Send data to the socket using overlapped WSASendMsg.
+sendBufMsg :: SocketAddress sa
+           => Socket            -- ^ Socket
+           -> sa                -- ^ Destination address
+           -> [(Ptr Word8,Int)] -- ^ Data to be sent
+           -> [Cmsg]            -- ^ Control messages
+           -> MsgFlag           -- ^ Message flags
+           -> IO Int            -- ^ The length actually sent
+sendBufMsg s sa bufsizs cmsgs flags =
+  withSocketAddress sa $ \addrPtr addrSize ->
+    withWSABuf bufsizs $ \(wsaBPtr, wsaBLen) ->
+      withCmsgs cmsgs $ \ctrlPtr ctrlLen ->
+        withSOCKET s $ \sock -> do
+          let msgHdr = MsgHdr {
+                  msgName    = addrPtr
+                , msgNameLen = fromIntegral addrSize
+                , msgBuffer    = wsaBPtr
+                , msgBufferLen = fromIntegral wsaBLen
+                , msgCtrl    = castPtr ctrlPtr
+                , msgCtrlLen = fromIntegral ctrlLen
+                , msgFlags   = 0
+                }
+              cflags = fromIntegral $ fromMsgFlag flags
+          wsaSendMsg <- loadWSASendMsg sock
+          with msgHdr $ \msgHdrPtr ->
+            ioBytes <$> withOverlapped "Network.Socket.sendBufMsg" sock 0
+                (\lpOverlapped -> do
+                    ret <- wsaSendMsg sock msgHdrPtr cflags nullPtr lpOverlapped nullPtr
+                    if ret == 0
+                        then pure CbPending
+                        else do
+                            le <- c_getLastError
+                            pure $ if le == #{const ERROR_IO_PENDING}
+                                then CbPending
+                                else CbError (fromIntegral le)
+                )
+                (\errCode numBytes -> case errCode of
+                    0 -> ioSuccess numBytes
+                    _ -> ioFailed $ ntStatusToDosError errCode
+                )
+
+-- | Receive data from the socket using overlapped WSARecvMsg.
+recvBufMsg :: SocketAddress sa
+           => Socket            -- ^ Socket
+           -> [(Ptr Word8,Int)] -- ^ A list of (buffer, buffer-length) pairs.
+           -> Int               -- ^ The buffer size for control messages.
+           -> MsgFlag           -- ^ Message flags
+           -> IO (sa,Int,[Cmsg],MsgFlag) -- ^ Source address, total bytes received, control messages and message flags
+recvBufMsg s bufsizs clen flags =
+  withNewSocketAddress $ \addrPtr addrSize ->
+    allocaBytes clen $ \ctrlPtr ->
+      withWSABuf bufsizs $ \(wsaBPtr, wsaBLen) ->
+        withSOCKET s $ \sock -> do
+          let msgHdr = MsgHdr {
+                  msgName    = addrPtr
+                , msgNameLen = fromIntegral addrSize
+                , msgBuffer    = wsaBPtr
+                , msgBufferLen = fromIntegral wsaBLen
+                , msgCtrl    = if clen == 0 then nullPtr else castPtr ctrlPtr
+                , msgCtrlLen = fromIntegral clen
+                , msgFlags   = fromIntegral $ fromMsgFlag flags
+                }
+          wsaRecvMsg <- loadWSARecvMsg sock
+          with msgHdr $ \msgHdrPtr -> do
+            len <- ioBytes <$> withOverlapped "Network.Socket.recvBufMsg" sock 0
+                (\lpOverlapped -> do
+                    ret <- wsaRecvMsg sock msgHdrPtr nullPtr lpOverlapped nullPtr
+                    if ret == 0
+                        then pure CbPending
+                        else do
+                            le <- c_getLastError
+                            -- WSAEMSGSIZE means a truncated message completed
+                            -- synchronously, but an IOCP completion is still
+                            -- queued.  Treat it as pending so the completion
+                            -- is consumed normally (it arrives as
+                            -- STATUS_BUFFER_OVERFLOW / ERROR_MORE_DATA).
+                            pure $ if le == #{const ERROR_IO_PENDING}
+                                       || le == #{const WSAEMSGSIZE}
+                                then CbPending
+                                else CbError (fromIntegral le)
+                )
+                (\errCode numBytes -> if errCode == 0
+                    then ioSuccess numBytes
+                    else
+                        -- Truncated message (WSAEMSGSIZE) — not an error,
+                        -- the data was received but the buffer was too small.
+                        let wserr = ntStatusToDosError errCode
+                            in if wserr == #{const ERROR_MORE_DATA}
+                                then ioSuccess numBytes
+                                else ioFailed wserr
+                )
+            sockaddr <- peekSocketAddress addrPtr
+                `catchIOError` \_ -> getPeerName (Generic.Socket (Right s))
+            hdr <- peek msgHdrPtr
+            let flags' = MsgFlag $ fromIntegral $ msgFlags hdr
+            -- When control messages were truncated, Control.len may
+            -- report the needed size rather than the actual buffer
+            -- size, causing cmsg_nxthdr to read past our buffer.
+            cmsgs' <- if flags' .&. MSG_CTRUNC /= mempty
+                then pure []
+                else parseCmsgs msgHdrPtr
+            return (sockaddr, len, cmsgs', flags')
+
+mkInvalidRecvArgError :: String -> IOError
+mkInvalidRecvArgError loc = ioeSetErrorString (mkIOError
+                                    InvalidArgument
+                                    loc Nothing Nothing) "non-positive length"
+
+-- | Convert an NTSTATUS code to a Win32 error code.
+foreign import ccall unsafe "RtlNtStatusToDosError"
+    ntStatusToDosError :: ErrCode -> ErrCode
+
+foreign import CALLCONV unsafe "WSASend"
+    c_WSASend :: SOCKET -> Ptr WSABuf -> DWORD -> Ptr DWORD -> DWORD
+              -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+foreign import CALLCONV unsafe "WSARecv"
+    c_WSARecv :: SOCKET -> Ptr WSABuf -> DWORD -> Ptr DWORD -> Ptr DWORD
+              -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+foreign import CALLCONV unsafe "WSASendTo"
+    c_WSASendTo :: SOCKET -> Ptr WSABuf -> DWORD -> Ptr DWORD -> DWORD
+                -> Ptr sa -> CInt -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+foreign import CALLCONV unsafe "WSARecvFrom"
+    c_WSARecvFrom :: SOCKET -> Ptr WSABuf -> DWORD -> Ptr DWORD -> Ptr DWORD
+                  -> Ptr sa -> Ptr CInt -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+-- WSASendMsg / WSARecvMsg are Winsock extension functions that must be
+-- loaded at runtime via WSAIoctl + SIO_GET_EXTENSION_FUNCTION_POINTER.
+-- The C loaders live in cbits/winSock.c.
+
+type WSASendMsgFn sa =
+    SOCKET -> Ptr (MsgHdr sa) -> DWORD -> Ptr DWORD
+    -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+type WSARecvMsgFn sa =
+    SOCKET -> Ptr (MsgHdr sa) -> Ptr DWORD
+    -> LPOVERLAPPED -> Ptr () -> IO CInt
+
+foreign import ccall unsafe "dynamic"
+    mkWSASendMsg :: FunPtr (WSASendMsgFn sa) -> WSASendMsgFn sa
+
+foreign import ccall unsafe "dynamic"
+    mkWSARecvMsg :: FunPtr (WSARecvMsgFn sa) -> WSARecvMsgFn sa
+
+foreign import ccall unsafe "loadWSASendMsg"
+    c_loadWSASendMsg :: SOCKET -> IO (FunPtr (WSASendMsgFn sa))
+
+foreign import ccall unsafe "loadWSARecvMsg"
+    c_loadWSARecvMsg :: SOCKET -> IO (FunPtr (WSARecvMsgFn sa))
+
+wsaSendMsgPtr :: TVar (Loaded a)
+wsaSendMsgPtr = unsafePerformIO $ newTVarIO Unloaded
+{-# NOINLINE wsaSendMsgPtr #-}
+
+wsaRecvMsgPtr :: TVar (Loaded a)
+wsaRecvMsgPtr = unsafePerformIO $ newTVarIO Unloaded
+{-# NOINLINE wsaRecvMsgPtr #-}
+
+loadWSASendMsg :: SOCKET -> IO (WSASendMsgFn sa)
+loadWSASendMsg = loadExtensionFunction wsaSendMsgPtr c_loadWSASendMsg mkWSASendMsg "WSASendMsg"
+
+loadWSARecvMsg :: SOCKET -> IO (WSARecvMsgFn sa)
+loadWSARecvMsg = loadExtensionFunction wsaRecvMsgPtr c_loadWSARecvMsg mkWSARecvMsg "WSARecvMsg"
+
+foreign import CALLCONV unsafe "ioctlsocket"
+    c_ioctlsocket :: CInt -> CLong -> Ptr CULong -> IO CInt
+
+foreign import CALLCONV unsafe "recv"
+    c_recv :: CInt -> Ptr CChar -> CSize -> CInt -> IO CInt
+
+foreign import CALLCONV unsafe "WSAGetLastError"
+    c_WSAGetLastError :: IO CInt

--- a/Network/Socket/Handle.hs
+++ b/Network/Socket/Handle.hs
@@ -1,10 +1,18 @@
-module Network.Socket.Handle where
+{-# LANGUAGE CPP #-}
+module Network.Socket.Handle (socketToHandle) where
 
 import qualified GHC.IO.Device (IODeviceType (Stream))
 import GHC.IO.Handle.FD (fdToHandle')
 import System.IO (BufferMode (..), Handle, IOMode (..), hSetBuffering)
 
+#if defined(mingw32_HOST_OS)
+import GHC.IO.Windows.Handle
+import GHC.IO.Handle.Windows
+import qualified Network.Socket.Types.WinIO as Win
+#endif
+
 import Network.Socket.Types
+import qualified Network.Socket.Types.Posix as Posix
 
 -- | Turns a Socket into an 'Handle'. By default, the new handle is
 -- unbuffered. Use 'System.IO.hSetBuffering' to change the buffering.
@@ -20,7 +28,22 @@ import Network.Socket.Types
 -- cooperate with peer's 'gracefulClose', i.e. proper shutdown
 -- sequence with appropriate handshakes specified by the protocol.
 socketToHandle :: Socket -> IOMode -> IO Handle
-socketToHandle s mode = invalidateSocket s err $ \oldfd -> do
+#if defined(mingw32_HOST_OS)
+socketToHandle = eitherSocket socketToHandlePosix socketToHandleWindows
+
+socketToHandleWindows :: Win.Socket -> IOMode -> IO Handle
+socketToHandleWindows s mode = Win.invalidateSocket s err $ \oldsock -> do
+    h <- mkHandleFromHANDLE (fromHANDLE oldsock :: Io NativeHandle) GHC.IO.Device.Stream "socket" mode Nothing
+    hSetBuffering h NoBuffering
+    return h
+  where
+    err _ = ioError $ userError $ "socketToHandle: socket is no longer valid"
+#else
+socketToHandle = socketToHandlePosix
+#endif
+
+socketToHandlePosix :: Posix.Socket -> IOMode -> IO Handle
+socketToHandlePosix s mode = Posix.invalidateSocket s err $ \oldfd -> do
     h <- fdToHandle' oldfd (Just GHC.IO.Device.Stream) True (show s) mode True {-bin-}
     hSetBuffering h NoBuffering
     return h

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -34,13 +34,13 @@ module Network.Socket.Options (
 
 import qualified Text.Read as P
 
-import Foreign.Marshal.Alloc (alloca)
-import Foreign.Marshal.Utils (with)
-
 import Network.Socket.Imports
-import Network.Socket.Internal
-import Network.Socket.Types
+import qualified Network.Socket.Options.Posix as Posix
+#if defined(mingw32_HOST_OS)
+import qualified Network.Socket.Options.WinIO as Win
+#endif
 import Network.Socket.ReadShow
+import Network.Socket.Types
 
 #include <sys/time.h>
 
@@ -424,12 +424,14 @@ setSockOpt :: Storable a
            -> SocketOption
            -> a
            -> IO ()
-setSockOpt s (SockOpt level opt) v = do
-    with v $ \ptr -> void $ do
-        let sz = fromIntegral $ sizeOf v
-        withFdSocket s $ \fd ->
-          throwSocketErrorIfMinus1_ "Network.Socket.setSockOpt" $
-          c_setsockopt fd level opt ptr sz
+#if defined(mingw32_HOST_OS)
+setSockOpt s (SockOpt opt level) = eitherSocket
+    (\ps -> Posix.setSockOpt ps opt level)
+    (\ws -> Win.setSockOpt ws opt level)
+    s
+#else
+setSockOpt s (SockOpt opt level) = Posix.setSockOpt s opt level
+#endif
 
 -- | Set a socket option value
 --
@@ -473,13 +475,14 @@ getSockOpt :: forall a . Storable a
            => Socket
            -> SocketOption -- Option Name
            -> IO a         -- Option Value
-getSockOpt s (SockOpt level opt) = do
-    alloca $ \ptr -> do
-        let sz = fromIntegral $ sizeOf (undefined :: a)
-        withFdSocket s $ \fd -> with sz $ \ptr_sz -> do
-            throwSocketErrorIfMinus1Retry_ "Network.Socket.getSockOpt" $
-                c_getsockopt fd level opt ptr ptr_sz
-        peek ptr
+#if defined(mingw32_HOST_OS)
+getSockOpt s (SockOpt opt level) = eitherSocket
+    (\ps -> Posix.getSockOpt ps opt level)
+    (\ws -> Win.getSockOpt ws opt level)
+    s
+#else
+getSockOpt s (SockOpt opt level) = Posix.getSockOpt s opt level
+#endif
 
 ----------------------------------------------------------------
 
@@ -555,10 +558,3 @@ instance Storable SocketTimeout where
             (#poke struct timeval, tv_sec)  ptr sec
             (#poke struct timeval, tv_usec) ptr usec
 #endif
-
-----------------------------------------------------------------
-
-foreign import CALLCONV unsafe "getsockopt"
-  c_getsockopt :: CInt -> CInt -> CInt -> Ptr a -> Ptr CInt -> IO CInt
-foreign import CALLCONV unsafe "setsockopt"
-  c_setsockopt :: CInt -> CInt -> CInt -> Ptr a -> CInt -> IO CInt

--- a/Network/Socket/Options/Posix.hsc
+++ b/Network/Socket/Options/Posix.hsc
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Network.Socket.Options.Posix (
+    getSockOpt,
+    setSockOpt
+) where
+
+##include "HsNetDef.h"
+
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Marshal.Utils (with)
+
+import Network.Socket.Imports
+import Network.Socket.Internal
+import Network.Socket.Types.Posix
+
+getSockOpt :: forall a . Storable a => Socket -> CInt -> CInt -> IO a
+getSockOpt s level opt = alloca $ \ptr -> do
+    let sz = fromIntegral $ sizeOf (undefined :: a)
+    withFdSocket s $ \fd -> with sz $ \ptr_sz -> do
+        throwSocketErrorIfMinus1Retry_ "Network.Socket.getSockOpt" $
+            c_getsockopt fd level opt ptr ptr_sz
+    peek ptr
+
+setSockOpt :: Storable a => Socket -> CInt -> CInt -> a -> IO ()
+setSockOpt s level opt v = with v $ \ptr -> void $ do
+    let sz = fromIntegral $ sizeOf v
+    withFdSocket s $ \fd ->
+      throwSocketErrorIfMinus1_ "Network.Socket.setSockOpt" $
+      c_setsockopt fd level opt ptr sz
+
+foreign import CALLCONV unsafe "getsockopt"
+  c_getsockopt :: CInt -> CInt -> CInt -> Ptr a -> Ptr CInt -> IO CInt
+foreign import CALLCONV unsafe "setsockopt"
+  c_setsockopt :: CInt -> CInt -> CInt -> Ptr a -> CInt -> IO CInt

--- a/Network/Socket/Options/WinIO.hsc
+++ b/Network/Socket/Options/WinIO.hsc
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Network.Socket.Options.WinIO (
+    getSockOpt,
+    setSockOpt
+) where
+
+##include "HsNetDef.h"
+
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Marshal.Utils (with)
+
+import Network.Socket.Imports
+import Network.Socket.Internal
+import Network.Socket.Types.WinIO
+
+getSockOpt :: forall a . Storable a => Socket -> CInt -> CInt -> IO a
+getSockOpt s level opt = alloca $ \ptr -> do
+    let sz = fromIntegral $ sizeOf (undefined :: a)
+    withSOCKET s $ \sock -> with sz $ \ptr_sz -> do
+        throwSocketErrorIfMinus1Retry_ "Network.Socket.getSockOpt" $
+            c_getsockopt sock level opt ptr ptr_sz
+    peek ptr
+
+setSockOpt :: Storable a => Socket -> CInt -> CInt -> a -> IO ()
+setSockOpt s level opt v = with v $ \ptr -> void $ do
+    let sz = fromIntegral $ sizeOf v
+    withSOCKET s $ \sock ->
+      throwSocketErrorIfMinus1_ "Network.Socket.setSockOpt" $
+      c_setsockopt sock level opt ptr sz
+
+foreign import CALLCONV unsafe "getsockopt"
+  c_getsockopt :: SOCKET -> CInt -> CInt -> Ptr a -> Ptr CInt -> IO CInt
+foreign import CALLCONV unsafe "setsockopt"
+  c_setsockopt :: SOCKET -> CInt -> CInt -> Ptr a -> CInt -> IO CInt

--- a/Network/Socket/Shutdown.hs
+++ b/Network/Socket/Shutdown.hs
@@ -86,7 +86,19 @@ bufSize :: Int
 bufSize = 1024
 
 recvEOFtimeout :: Socket -> Int -> Ptr Word8 -> IO ()
+#if defined(mingw32_HOST_OS)
+-- On Windows with the WinIO (IOCP) I/O manager, GHC's withOverlappedEx
+-- converts async exceptions (including the one thrown by timeout) into a
+-- synchronous IOException via `throwWinErr ... 0`
+-- ("The operation completed successfully").
+-- `timeout` does not recognise this IOException as
+-- its own exception, so it escapes.
+-- Should be safe since we're only calling this on shutdown (see above).
+recvEOFtimeout s tmout0 buf = void $ timeout tmout0 $
+    recvBuf s buf bufSize `E.catch` (\(_ :: E.IOException) -> pure 0)
+#else
 recvEOFtimeout s tmout0 buf = void $ timeout tmout0 $ recvBuf s buf bufSize
+#endif
 
 #if !defined(mingw32_HOST_OS)
 data Wait = MoreData | TimeoutTripped

--- a/Network/Socket/Syscall.hs
+++ b/Network/Socket/Syscall.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 #include "HsNetDef.h"
 
 module Network.Socket.Syscall where
 
+import Data.Bifunctor
 import Foreign.Marshal.Utils (with)
 import qualified Control.Exception as E
 # if defined(mingw32_HOST_OS)
@@ -29,10 +31,18 @@ import Network.Socket.Imports
 import Network.Socket.Internal
 import Network.Socket.Options
 import Network.Socket.Types
+import qualified Network.Socket.Types.Posix as Posix
+
+import qualified Network.Socket.Syscall.Posix as Posix
+#if defined(mingw32_HOST_OS)
+import qualified Network.Socket.Types.WinIO as Win
+import qualified Network.Socket.Syscall.WinIO as Win
+import GHC.IO.SubSystem
+#endif
 
 -- ----------------------------------------------------------------------------
--- On Windows, our sockets are not put in non-blocking mode (non-blocking
--- is not supported for regular file descriptors on Windows, and it would
+-- In the Posix event manager, our sockets are not put in non-blocking mode
+-- (non-blocking for regular file descriptors on Windows in the PEM, and it would
 -- be a pain to support it only for sockets).  So there are two cases:
 --
 --  - the threaded RTS uses safe calls for socket operations to get
@@ -75,58 +85,11 @@ socket :: Family         -- Family Name (usually AF_INET)
        -> SocketType     -- Socket Type (usually Stream)
        -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)
        -> IO Socket      -- Unconnected Socket
-socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
-    -- Let's ensure that the socket (file descriptor) is closed even on
-    -- asynchronous exceptions.
-    setNonBlock fd
-    s <- mkSocket fd
-    -- This socket is not managed by the IO manager yet.
-    -- So, we don't have to call "close" which uses "closeFdWith".
-    unsetIPv6Only s
-    setDontFragment s
-    return s
-  where
-    create = do
-        let c_stype = modifyFlag $ packSocketType stype
-        throwSocketErrorIfMinus1Retry "Network.Socket.socket" $
-            c_socket (packFamily family) c_stype protocol
-
-#ifdef HAVE_ADVANCED_SOCKET_FLAGS
-    modifyFlag c_stype = c_stype .|. sockNonBlock
+#if defined(mingw32_HOST_OS)
+socket fam st p = Socket <$>
+    fmap Left (Posix.socket fam st p) <!> fmap Right (Win.socket fam st p)
 #else
-    modifyFlag c_stype = c_stype
-#endif
-
-#ifdef HAVE_ADVANCED_SOCKET_FLAGS
-    setNonBlock _ = return ()
-#else
-    setNonBlock fd = setNonBlockIfNeeded fd
-#endif
-
-#if HAVE_DECL_IPV6_V6ONLY
-    unsetIPv6Only s = when (family == AF_INET6 && stype `elem` [Stream, Datagram]) $
-# if defined(mingw32_HOST_OS)
-      -- The IPv6Only option is only supported on Windows Vista and later,
-      -- so trying to change it might throw an error.
-      setSocketOption s IPv6Only 0 `catchIOError` \_ -> return ()
-# elif defined(openbsd_HOST_OS)
-      -- don't change IPv6Only
-      return ()
-# else
-      -- The default value of the IPv6Only option is platform specific,
-      -- so we explicitly set it to 0 to provide a common default.
-      setSocketOption s IPv6Only 0
-# endif
-#else
-    unsetIPv6Only _ = return ()
-#endif
-
-    setDontFragment s = when (family == AF_INET) $
-#if HAVE_DECL_IP_DONTFRAG || HAVE_DECL_IP_MTU_DISCOVER
-      setSocketOption s DontFragment 1
-#else
-      -- do nothing
-      return ()
+socket = Posix.socket
 #endif
 
 
@@ -139,39 +102,21 @@ socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
 -- 'defaultPort' is passed then the system assigns the next available
 -- use port.
 bind :: SocketAddress sa => Socket -> sa -> IO ()
-bind s sa = withSocketAddress sa $ \p_sa siz -> void $ withFdSocket s $ \fd -> do
-  let sz = fromIntegral siz
-  throwSocketErrorIfMinus1Retry "Network.Socket.bind" $ c_bind fd p_sa sz
+#if defined(mingw32_HOST_OS)
+bind = eitherSocket Posix.bind Win.bind
+#else
+bind = Posix.bind
+#endif
 
 -----------------------------------------------------------------------------
 -- Connecting a socket
 
 -- | Connect to a remote socket at address.
-connect :: SocketAddress sa => Socket -> sa -> IO ()
-connect s sa = withSocketsDo $ withSocketAddress sa $ \p_sa sz ->
-    connectLoop s p_sa (fromIntegral sz)
-
-connectLoop :: SocketAddress sa => Socket -> Ptr sa -> CInt -> IO ()
-connectLoop s p_sa sz = withFdSocket s $ \fd -> loop fd
-  where
-    errLoc = "Network.Socket.connect: " ++ show s
-    loop fd = do
-       r <- c_connect fd p_sa sz
-       when (r == -1) $ do
+connect :: Socket -> SockAddr -> IO ()
 #if defined(mingw32_HOST_OS)
-           throwSocketError errLoc
+connect = eitherSocket Posix.connect Win.connect
 #else
-           err <- getErrno
-           case () of
-             _ | err == eINTR       -> loop fd
-             _ | err == eINPROGRESS -> connectBlocked
---           _ | err == eAGAIN      -> connectBlocked
-             _otherwise             -> throwSocketError errLoc
-
-    connectBlocked = do
-       withFdSocket s $ threadWaitWrite . fromIntegral
-       err <- getSocketOption s SoError
-       when (err /= 0) $ throwSocketErrorCode errLoc (fromIntegral err)
+connect = Posix.connect
 #endif
 
 -----------------------------------------------------------------------------
@@ -181,9 +126,11 @@ connectLoop s p_sa sz = withFdSocket s $ \fd -> loop fd
 -- specifies the maximum number of queued connections and should be at
 -- least 1; the maximum value is system-dependent (usually 5).
 listen :: Socket -> Int -> IO ()
-listen s backlog = withFdSocket s $ \fd -> do
-    throwSocketErrorIfMinus1Retry_ "Network.Socket.listen" $
-        c_listen fd $ fromIntegral backlog
+#if defined(mingw32_HOST_OS)
+listen = eitherSocket Posix.listen Win.listen
+#else
+listen = Posix.listen
+#endif
 
 -----------------------------------------------------------------------------
 -- Accept
@@ -201,66 +148,10 @@ listen s backlog = withFdSocket s $ \fd -> do
 -- to the socket on the other end of the connection.
 -- On Unix, FD_CLOEXEC is set to the new 'Socket'.
 accept :: SocketAddress sa => Socket -> IO (Socket, sa)
-accept listing_sock = withNewSocketAddress $ \new_sa sz ->
-    withFdSocket listing_sock $ \listing_fd -> do
- new_sock <- E.bracketOnError (callAccept listing_fd new_sa sz) c_close mkSocket
- new_addr <- peekSocketAddress new_sa
- return (new_sock, new_addr)
-  where
 #if defined(mingw32_HOST_OS)
-     callAccept fd sa sz
-       | threaded  = with (fromIntegral sz) $ \ ptr_len ->
-                       throwSocketErrorIfMinus1Retry "Network.Socket.accept" $
-                         c_accept_safe fd sa ptr_len
-       | otherwise = do
-             bracket (c_newAcceptParams fd (fromIntegral sz) sa) c_free $ \paramData -> do
-                 rc     <- asyncDoProc c_acceptDoProc paramData
-                 new_fd <- c_acceptNewSock paramData
-                 when (rc /= 0) $
-                     throwSocketErrorCode "Network.Socket.accept" (fromIntegral rc)
-                 return new_fd
+accept (Socket s) = case s of
+    Left (p :: Posix.Socket) -> first (Socket . Left) <$> Posix.accept p
+    Right (w :: Win.Socket) -> first (Socket . Right) <$> Win.accept w
 #else
-     callAccept fd sa sz = with (fromIntegral sz) $ \ ptr_len -> do
-# ifdef HAVE_ADVANCED_SOCKET_FLAGS
-       throwSocketErrorWaitRead listing_sock "Network.Socket.accept"
-                        (c_accept4 fd sa ptr_len (sockNonBlock .|. sockCloexec))
-# else
-       new_fd <- throwSocketErrorWaitRead listing_sock "Network.Socket.accept"
-                        (c_accept fd sa ptr_len)
-       setNonBlockIfNeeded new_fd
-       setCloseOnExecIfNeeded new_fd
-       return new_fd
-# endif /* HAVE_ADVANCED_SOCKET_FLAGS */
-#endif
-
-foreign import CALLCONV unsafe "socket"
-  c_socket :: CInt -> CInt -> CInt -> IO CInt
-foreign import CALLCONV unsafe "bind"
-  c_bind :: CInt -> Ptr sa -> CInt{-CSockLen???-} -> IO CInt
-foreign import CALLCONV SAFE_ON_WIN "connect"
-  c_connect :: CInt -> Ptr sa -> CInt{-CSockLen???-} -> IO CInt
-foreign import CALLCONV unsafe "listen"
-  c_listen :: CInt -> CInt -> IO CInt
-
-#ifdef HAVE_ADVANCED_SOCKET_FLAGS
-foreign import CALLCONV unsafe "accept4"
-  c_accept4 :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> CInt -> IO CInt
-#else
-foreign import CALLCONV unsafe "accept"
-  c_accept :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> IO CInt
-#endif
-
-#if defined(mingw32_HOST_OS)
-foreign import CALLCONV safe "accept"
-  c_accept_safe :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> IO CInt
-foreign import ccall unsafe "rtsSupportsBoundThreads"
-  threaded :: Bool
-foreign import ccall unsafe "HsNet.h acceptNewSock"
-  c_acceptNewSock :: Ptr () -> IO CInt
-foreign import ccall unsafe "HsNet.h newAcceptParams"
-  c_newAcceptParams :: CInt -> CInt -> Ptr a -> IO (Ptr ())
-foreign import ccall unsafe "HsNet.h &acceptDoProc"
-  c_acceptDoProc :: FunPtr (Ptr () -> IO Int)
-foreign import ccall unsafe "free"
-  c_free:: Ptr a -> IO ()
+accept = Posix.accept
 #endif

--- a/Network/Socket/Syscall/Posix.hs
+++ b/Network/Socket/Syscall/Posix.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE CPP #-}
+
+#include "HsNetDef.h"
+
+module Network.Socket.Syscall.Posix where
+
+import Foreign.Marshal.Utils (with)
+import qualified Control.Exception as E
+# if defined(mingw32_HOST_OS)
+import System.IO.Error (catchIOError)
+#endif
+
+#if defined(mingw32_HOST_OS)
+import Control.Exception (bracket)
+import GHC.Conc (asyncDoProc)
+#else
+import Foreign.C.Error (getErrno, eINTR, eINPROGRESS)
+import GHC.Conc (threadWaitWrite)
+#endif
+
+#ifdef HAVE_ADVANCED_SOCKET_FLAGS
+import Network.Socket.Cbits
+#else
+import Network.Socket.Fcntl
+#endif
+
+import Network.Socket.Imports
+import Network.Socket.Internal
+import Network.Socket.Options
+import Network.Socket.Types (
+    Family(..),
+    SocketAddress,
+    SocketType(..),
+    ProtocolNumber,
+    withSocketAddress,
+    withNewSocketAddress,
+    peekSocketAddress
+    )
+import qualified Network.Socket.Types as Generic
+import Network.Socket.Types.Posix
+
+-- ----------------------------------------------------------------------------
+-- In the Posix event manager, our sockets are not put in non-blocking mode
+-- (non-blocking for regular file descriptors on Windows in the PEM, and it would
+-- be a pain to support it only for sockets).  So there are two cases:
+--
+--  - the threaded RTS uses safe calls for socket operations to get
+--    non-blocking I/O, just like the rest of the I/O library
+--
+--  - with the non-threaded RTS, only some operations on sockets will be
+--    non-blocking.  Reads and writes go through the normal async I/O
+--    system.  accept() uses asyncDoProc so is non-blocking.  A handful
+--    of others (recvFrom, sendFd, recvFd) will block all threads - if this
+--    is a problem, -threaded is the workaround.
+--
+
+socket :: Family         -- Family Name (usually AF_INET)
+       -> SocketType     -- Socket Type (usually Stream)
+       -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)
+       -> IO Socket      -- Unconnected Socket
+socket family stype protocol = E.bracketOnError create c_close $ \fd -> do
+    -- Let's ensure that the socket (file descriptor) is closed even on
+    -- asynchronous exceptions.
+    setNonBlock fd
+    s <- mkSocket fd
+    -- This socket is not managed by the IO manager yet.
+    -- So, we don't have to call "close" which uses "closeFdWith".
+    unsetIPv6Only s
+    setDontFragment s
+    return s
+  where
+    create = do
+        let c_stype = modifyFlag $ packSocketType stype
+        throwSocketErrorIfMinus1Retry "Network.Socket.socket" $
+            c_socket (packFamily family) c_stype protocol
+
+#ifdef HAVE_ADVANCED_SOCKET_FLAGS
+    modifyFlag c_stype = c_stype .|. sockNonBlock
+#else
+    modifyFlag c_stype = c_stype
+#endif
+
+#ifdef HAVE_ADVANCED_SOCKET_FLAGS
+    setNonBlock _ = return ()
+#else
+    setNonBlock fd = setNonBlockIfNeeded fd
+#endif
+
+#if HAVE_DECL_IPV6_V6ONLY
+    unsetIPv6Only s = when (family == AF_INET6 && stype `elem` [Stream, Datagram]) $
+# if defined(mingw32_HOST_OS)
+      -- The IPv6Only option is only supported on Windows Vista and later,
+      -- so trying to change it might throw an error.
+      setSocketOption (Generic.Socket $ Left s) IPv6Only 0 `catchIOError` \_ -> return ()
+# elif defined(openbsd_HOST_OS)
+      -- don't change IPv6Only
+      return ()
+# else
+      -- The default value of the IPv6Only option is platform specific,
+      -- so we explicitly set it to 0 to provide a common default.
+      setSocketOption s IPv6Only 0
+# endif
+#else
+    unsetIPv6Only _ = return ()
+#endif
+
+    setDontFragment s = when (family == AF_INET) $
+#if HAVE_DECL_IP_DONTFRAG || HAVE_DECL_IP_MTU_DISCOVER
+# if defined(mingw32_HOST_OS)
+      setSocketOption (Generic.Socket $ Left s) DontFragment 1
+# else
+      setSocketOption s DontFragment 1
+# endif
+#else
+      -- do nothing
+      return ()
+#endif
+
+
+bind :: SocketAddress sa => Socket -> sa -> IO ()
+bind s sa = withSocketAddress sa $ \p_sa siz -> void $ withFdSocket s $ \fd -> do
+  let sz = fromIntegral siz
+  throwSocketErrorIfMinus1Retry "Network.Socket.bind" $ c_bind fd p_sa sz
+
+connect :: SocketAddress sa => Socket -> sa -> IO ()
+connect s sa = withSocketsDo $ withSocketAddress sa $ \p_sa sz ->
+    connectLoop s p_sa (fromIntegral sz)
+
+connectLoop :: SocketAddress sa => Socket -> Ptr sa -> CInt -> IO ()
+connectLoop s p_sa sz = withFdSocket s $ \fd -> loop fd
+  where
+    errLoc = "Network.Socket.connect: " ++ show s
+    loop fd = do
+       r <- c_connect fd p_sa sz
+       when (r == -1) $ do
+#if defined(mingw32_HOST_OS)
+           throwSocketError errLoc
+#else
+           err <- getErrno
+           case () of
+             _ | err == eINTR       -> loop fd
+             _ | err == eINPROGRESS -> connectBlocked
+--           _ | err == eAGAIN      -> connectBlocked
+             _otherwise             -> throwSocketError errLoc
+
+    connectBlocked = do
+       withFdSocket s $ threadWaitWrite . fromIntegral
+       err <- getSocketOption s SoError
+       when (err /= 0) $ throwSocketErrorCode errLoc (fromIntegral err)
+#endif
+
+
+listen :: Socket -> Int -> IO ()
+listen s backlog = withFdSocket s $ \fd -> do
+    throwSocketErrorIfMinus1Retry_ "Network.Socket.listen" $
+        c_listen fd $ fromIntegral backlog
+
+
+accept :: SocketAddress sa => Socket -> IO (Socket, sa)
+accept listing_sock = withNewSocketAddress $ \new_sa sz ->
+    withFdSocket listing_sock $ \listing_fd -> do
+ new_sock <- E.bracketOnError (callAccept listing_fd new_sa sz) c_close mkSocket
+ new_addr <- peekSocketAddress new_sa
+ return (new_sock, new_addr)
+  where
+#if defined(mingw32_HOST_OS)
+     callAccept fd sa sz
+       | threaded  = with (fromIntegral sz) $ \ ptr_len ->
+                       throwSocketErrorIfMinus1Retry "Network.Socket.accept" $
+                         c_accept_safe fd sa ptr_len
+       | otherwise = do
+             bracket (c_newAcceptParams fd (fromIntegral sz) sa) c_free $ \paramData -> do
+                 rc     <- asyncDoProc c_acceptDoProc paramData
+                 new_fd <- c_acceptNewSock paramData
+                 when (rc /= 0) $
+                     throwSocketErrorCode "Network.Socket.accept" (fromIntegral rc)
+                 return new_fd
+#else
+     callAccept fd sa sz = with (fromIntegral sz) $ \ ptr_len -> do
+# ifdef HAVE_ADVANCED_SOCKET_FLAGS
+       throwSocketErrorWaitRead listing_sock "Network.Socket.accept"
+                        (c_accept4 fd sa ptr_len (sockNonBlock .|. sockCloexec))
+# else
+       new_fd <- throwSocketErrorWaitRead listing_sock "Network.Socket.accept"
+                        (c_accept fd sa ptr_len)
+       setNonBlockIfNeeded new_fd
+       setCloseOnExecIfNeeded new_fd
+       return new_fd
+# endif /* HAVE_ADVANCED_SOCKET_FLAGS */
+#endif
+
+foreign import CALLCONV unsafe "socket"
+  c_socket :: CInt -> CInt -> CInt -> IO CInt
+foreign import CALLCONV unsafe "bind"
+  c_bind :: CInt -> Ptr sa -> CInt{-CSockLen???-} -> IO CInt
+foreign import CALLCONV SAFE_ON_WIN "connect"
+  c_connect :: CInt -> Ptr sa -> CInt{-CSockLen???-} -> IO CInt
+foreign import CALLCONV unsafe "listen"
+  c_listen :: CInt -> CInt -> IO CInt
+
+#ifdef HAVE_ADVANCED_SOCKET_FLAGS
+foreign import CALLCONV unsafe "accept4"
+  c_accept4 :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> CInt -> IO CInt
+#else
+foreign import CALLCONV unsafe "accept"
+  c_accept :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> IO CInt
+#endif
+
+#if defined(mingw32_HOST_OS)
+foreign import CALLCONV safe "accept"
+  c_accept_safe :: CInt -> Ptr sa -> Ptr CInt{-CSockLen???-} -> IO CInt
+foreign import ccall unsafe "rtsSupportsBoundThreads"
+  threaded :: Bool
+foreign import ccall unsafe "HsNet.h acceptNewSock"
+  c_acceptNewSock :: Ptr () -> IO CInt
+foreign import ccall unsafe "HsNet.h newAcceptParams"
+  c_newAcceptParams :: CInt -> CInt -> Ptr a -> IO (Ptr ())
+foreign import ccall unsafe "HsNet.h &acceptDoProc"
+  c_acceptDoProc :: FunPtr (Ptr () -> IO Int)
+foreign import ccall unsafe "free"
+  c_free:: Ptr a -> IO ()
+#endif

--- a/Network/Socket/Syscall/WinIO.hsc
+++ b/Network/Socket/Syscall/WinIO.hsc
@@ -1,0 +1,257 @@
+{-# LANGUAGE CPP #-}
+module Network.Socket.Syscall.WinIO where
+
+#include "HsNet.h"
+##include "HsNetDef.h"
+
+import Control.Concurrent.STM
+import qualified Control.Exception as E
+import Foreign.Marshal.Alloc (allocaBytes, alloca)
+import Foreign.Marshal.Utils (with)
+import GHC.Event.Windows
+import GHC.Windows
+import Network.Socket.Imports
+import Network.Socket.Internal
+import Network.Socket.Options
+import Network.Socket.Types (
+    Family(..),
+    SocketAddress,
+    SocketType(..),
+    ProtocolNumber,
+    withSocketAddress,
+    peekSocketAddress
+    )
+import qualified Network.Socket.Types as Generic
+import Network.Socket.Types.WinIO
+import Network.Socket.Win32.Load
+import System.IO.Error (catchIOError)
+import System.IO.Unsafe (unsafePerformIO)
+
+socket :: Family         -- Family Name (usually AF_INET)
+    -> SocketType     -- Socket Type (usually Stream)
+    -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)
+    -> IO Socket      -- Unconnected Socket
+socket family stype protocol = E.bracketOnError create c_close $ \s -> do
+    associateHandle' s
+    sock <- mkSocket s
+    unsetIPv6Only sock
+    setDontFragment sock
+    pure sock
+  where
+    create = do
+        s <- c_socket (packFamily family) (packSocketType stype) protocol
+        when (s == invalidSocket) $ throwSocketError "Network.Socket.socket"
+        pure s
+#if HAVE_DECL_IPV6_V6ONLY
+    unsetIPv6Only s = when (family == AF_INET6 && stype `elem` [Stream, Datagram]) $
+      -- The IPv6Only option is only supported on Windows Vista and later,
+      -- so trying to change it might throw an error.
+      setSocketOption (Generic.Socket $ Right s) IPv6Only 0 `catchIOError` \_ -> return ()
+#else
+    unsetIPv6Only _ = return ()
+#endif
+    setDontFragment s = when (family == AF_INET) $
+#if HAVE_DECL_IP_DONTFRAG || HAVE_DECL_IP_MTU_DISCOVER
+      setSocketOption (Generic.Socket $ Right s) DontFragment 1
+#else
+      -- do nothing
+      return ()
+#endif
+
+foreign import CALLCONV unsafe "socket"
+    c_socket :: CInt -> CInt -> CInt -> IO SOCKET
+
+bind :: SocketAddress sa => Socket -> sa -> IO ()
+bind s sa = withSocketAddress sa $ \p_sa siz -> withSOCKET s $ \sock -> do
+    let sz = fromIntegral siz
+    void $ throwSocketErrorIfMinus1Retry "Network.Socket.bind" $ c_bind sock p_sa sz
+
+foreign import CALLCONV unsafe "bind"
+    c_bind :: SOCKET -> Ptr sa -> CInt{-CSockLen???-} -> IO CInt
+
+connect :: Socket -> Generic.SockAddr -> IO ()
+connect s saddr = do
+    -- NB: ConnectEx assumes the socket is already bound
+    bindTo <- case saddr of
+        Generic.SockAddrInet _ _ -> pure $ Generic.SockAddrInet 0 0
+        Generic.SockAddrInet6 _ _ _ _ -> pure $ Generic.SockAddrInet6 0 0 (0, 0, 0, 0) 0
+        Generic.SockAddrUnix _ -> throwSocketError "Network.Socket.connect: Unix socket on Windows"
+    bind s bindTo
+    withSOCKET s $ \sock -> do
+        cex <- loadConnectEx sock
+        withSocketAddress saddr $ \p_sa sz -> do
+            withOverlapped "Network.Socket.connect: ConnectEx" sock 0
+                (\lpOverlapped -> do
+                    ret <- cex sock p_sa (fromIntegral sz) nullPtr 0 nullPtr lpOverlapped
+                    if ret
+                        then pure CbPending
+                        else do
+                        le <- c_getLastError
+                        pure $ if le == #{const ERROR_IO_PENDING}
+                            then CbPending
+                            else CbError (fromIntegral le)
+                )
+                (\errCode _ -> case errCode of
+                    0 -> ioSuccess 0
+                    -- See below
+                    _ -> ioFailed $ ntStatusToDosError errCode
+                )
+
+            -- Make the connected socket fully functional.
+            -- Required for shutdown/getpeername/getsockname to work.
+            void $ throwSocketErrorIfMinus1Retry
+                "Network.Socket.connect: setsockopt(SO_UPDATE_CONNECT_CONTEXT)" $
+                c_setsockopt sock #{const SOL_SOCKET} #{const SO_UPDATE_CONNECT_CONTEXT}
+                    nullPtr 0
+
+-- | Convert an NTSTATUS code to a Win32 error code.
+-- The GHC IOCP manager delivers NTSTATUS values in completion callbacks;
+-- Winsock functions expect Win32 error codes.
+foreign import ccall unsafe "RtlNtStatusToDosError"
+    ntStatusToDosError :: ErrCode -> ErrCode
+
+connectExPtr :: TVar (Loaded a)
+connectExPtr = unsafePerformIO $ newTVarIO Unloaded
+{-# NOINLINE connectExPtr #-}
+
+loadConnectEx :: SOCKET -> IO (ConnectEx sa)
+loadConnectEx = loadExtensionFunction connectExPtr c_loadConnectEx mkConnectEx "ConnectEx"
+
+type ConnectEx sa =
+    SOCKET              -- s
+    -> Ptr sa           -- name
+    -> CInt             -- namelen
+    -> Ptr ()           -- lpSendBuffer (nullable)
+    -> DWORD            -- dwSendDataLength
+    -> Ptr DWORD        -- lpdwBytesSent
+    -> LPOVERLAPPED   -- lpOverlapped
+    -> IO BOOL
+
+foreign import ccall unsafe "dynamic"
+    mkConnectEx :: FunPtr (ConnectEx sa) -> ConnectEx sa
+
+foreign import ccall unsafe "loadConnectEx"
+    c_loadConnectEx :: SOCKET -> IO (FunPtr (ConnectEx sa))
+
+
+listen :: Socket -> Int -> IO ()
+listen s backlog = withSOCKET s $ \sock ->
+    throwSocketErrorIfMinus1Retry_ "Network.Socket.listen" $
+        c_listen sock (fromIntegral backlog)
+
+foreign import CALLCONV unsafe "listen"
+    c_listen :: SOCKET -> CInt -> IO CInt
+
+
+accept :: SocketAddress sa => Socket -> IO (Socket, sa)
+accept listing_sock = withSOCKET listing_sock $ \lsock -> do
+    aex <- loadAcceptEx lsock
+    gasas <- loadGetAcceptExSockaddrs lsock
+
+    -- AcceptEx buffer: no receive data, just addresses.
+    -- Each address slot must be >= sizeof(sockaddr_storage) + 16.
+    let addrLen = #{size struct sockaddr_storage} + 16 :: DWORD
+        bufSize = fromIntegral (2 * addrLen) :: Int
+
+    -- AcceptEx requires a pre-created, unbound accept socket.
+    asock <- c_createPeerSocket lsock
+    when (asock == invalidSocket) $
+        throwSocketError "Network.Socket.accept: can't create peer socket"
+
+    E.bracketOnError (pure asock) c_close $ \_ ->
+      allocaBytes bufSize $ \buf -> do
+        -- Overlapped AcceptEx on the LISTENING socket's IOCP handle
+        void $ withOverlapped "Network.Socket.accept" lsock 0
+            (\lpOverlapped -> do
+                ret <- aex lsock asock buf 0 addrLen addrLen nullPtr lpOverlapped
+                if ret
+                    then pure CbPending  -- AcceptEx TRUE still queues IOCP completion
+                    else do
+                        le <- c_getLastError
+                        pure $ if le == #{const ERROR_IO_PENDING}
+                            then CbPending
+                            else CbError (fromIntegral le)
+            )
+            (\errCode _ -> case errCode of
+                0 -> ioSuccess 0
+                _ -> ioFailed $ ntStatusToDosError errCode
+            )
+
+        -- Make accepted socket inherit listen socket properties.
+        -- Required for getpeername/getsockname to work.
+        with lsock $ \lsockPtr ->
+            void $ throwSocketErrorIfMinus1Retry
+                "Network.Socket.accept" $
+                c_setsockopt asock #{const SOL_SOCKET} #{const SO_UPDATE_ACCEPT_CONTEXT}
+                    (castPtr lsockPtr) (fromIntegral $ sizeOf lsock)
+
+        -- Extract remote address from AcceptEx output buffer
+        alloca $ \localPtrPtr ->
+          alloca $ \localLenPtr ->
+            alloca $ \remotePtrPtr ->
+              alloca $ \remoteLenPtr -> do
+                gasas buf 0 addrLen addrLen
+                    localPtrPtr localLenPtr remotePtrPtr remoteLenPtr
+                remotePtr <- peek remotePtrPtr
+                remoteAddr <- peekSocketAddress (castPtr remotePtr)
+
+                -- Register with IOCP and create Socket wrapper
+                associateHandle' asock
+                sock <- mkSocket asock
+                return (sock, remoteAddr)
+
+-- AcceptEx function pointer type
+type AcceptExFn =
+    SOCKET       -- sListenSocket
+    -> SOCKET    -- sAcceptSocket
+    -> Ptr ()    -- lpOutputBuffer
+    -> DWORD     -- dwReceiveDataLength
+    -> DWORD     -- dwLocalAddressLength
+    -> DWORD     -- dwRemoteAddressLength
+    -> Ptr DWORD -- lpdwBytesReceived
+    -> LPOVERLAPPED
+    -> IO BOOL
+
+-- GetAcceptExSockaddrs function pointer type
+type GetAcceptExSockaddrsFn =
+    Ptr ()       -- lpOutputBuffer
+    -> DWORD     -- dwReceiveDataLength
+    -> DWORD     -- dwLocalAddressLength
+    -> DWORD     -- dwRemoteAddressLength
+    -> Ptr (Ptr ()) -- LocalSockaddr (output)
+    -> Ptr CInt     -- LocalSockaddrLength (output)
+    -> Ptr (Ptr ()) -- RemoteSockaddr (output)
+    -> Ptr CInt     -- RemoteSockaddrLength (output)
+    -> IO ()
+
+foreign import ccall unsafe "dynamic"
+    mkAcceptEx :: FunPtr AcceptExFn -> AcceptExFn
+
+foreign import ccall unsafe "dynamic"
+    mkGetAcceptExSockaddrs :: FunPtr GetAcceptExSockaddrsFn -> GetAcceptExSockaddrsFn
+
+foreign import ccall unsafe "loadAcceptEx"
+    c_loadAcceptEx :: SOCKET -> IO (FunPtr AcceptExFn)
+
+foreign import ccall unsafe "loadGetAcceptExSockaddrs"
+    c_loadGetAcceptExSockaddrs :: SOCKET -> IO (FunPtr GetAcceptExSockaddrsFn)
+
+foreign import ccall unsafe "createPeerSocket"
+    c_createPeerSocket :: SOCKET -> IO SOCKET
+
+foreign import CALLCONV unsafe "setsockopt"
+    c_setsockopt :: SOCKET -> CInt -> CInt -> Ptr a -> CInt -> IO CInt
+
+acceptExPtr :: TVar (Loaded a)
+acceptExPtr = unsafePerformIO $ newTVarIO Unloaded
+{-# NOINLINE acceptExPtr #-}
+
+loadAcceptEx :: SOCKET -> IO AcceptExFn
+loadAcceptEx = loadExtensionFunction acceptExPtr c_loadAcceptEx mkAcceptEx "AcceptEx"
+
+getAcceptExSockaddrsPtr :: TVar (Loaded a)
+getAcceptExSockaddrsPtr = unsafePerformIO $ newTVarIO Unloaded
+{-# NOINLINE getAcceptExSockaddrsPtr #-}
+
+loadGetAcceptExSockaddrs :: SOCKET -> IO GetAcceptExSockaddrsFn
+loadGetAcceptExSockaddrs = loadExtensionFunction getAcceptExSockaddrsPtr c_loadGetAcceptExSockaddrs mkGetAcceptExSockaddrs "GetAcceptExSockaddrs"

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -13,17 +13,18 @@
 
 module Network.Socket.Types (
     -- * Socket type
-      Socket
+      Socket (..)
+#if defined(mingw32_HOST_OS)
+    , eitherSocket
+#endif
     , withFdSocket
     , unsafeFdSocket
     , touchSocket
     , socketToFd
     , fdSocket
     , mkSocket
-    , invalidateSocket
     , close
     , close'
-    , c_close
     -- * Types of socket
     , SocketType(GeneralSocketType, UnsupportedSocketType, NoSocketType
                 , Stream, Datagram, Raw, RDM, SeqPacket)
@@ -84,16 +85,8 @@ module Network.Socket.Types (
     , In6Addr(..)
     ) where
 
-import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef', mkWeakIORef)
-import Foreign.C.Error (throwErrno)
 import Foreign.Marshal.Alloc
-import GHC.Conc (closeFdWith)
-import System.Posix.Types (Fd)
 import Control.DeepSeq (NFData (..))
-import GHC.Exts (touch##)
-import GHC.IORef (IORef (..))
-import GHC.STRef (STRef (..))
-import GHC.IO (IO (..))
 
 import qualified Text.Read as P
 
@@ -104,17 +97,33 @@ import Network.Socket.Imports
 ----- readshow module import
 import Network.Socket.ReadShow
 
+import qualified Network.Socket.Types.Posix as Posix
 
 -----------------------------------------------------------------------------
 
--- | Basic type for a socket.
-data Socket = Socket (IORef CInt) CInt {- for Show -}
+-- If we're on a Windows system, we might be using the legacy
+-- Posix emulation event manager (where everything is blocking IO),
+-- or we may have access to the nice new WinIO event manager,
+-- which does actual async IO with IO Completion Ports
+-- (almost, but not quite, entirely unlike epoll/kqueue).
+#if defined(mingw32_HOST_OS)
+import qualified Network.Socket.Types.WinIO as Win
+
+newtype Socket = Socket (Either Posix.Socket Win.Socket)
+    deriving (Eq)
+
+eitherSocket :: (Posix.Socket -> a) -> (Win.Socket -> a) -> Socket -> a
+eitherSocket p w (Socket es) = either p w es
+{-# INLINE eitherSocket #-}
 
 instance Show Socket where
-    show (Socket _ ofd) = "<socket: " ++ show ofd ++ ">"
+    show = eitherSocket show show
 
-instance Eq Socket where
-    Socket ref1 _ == Socket ref2 _ = ref1 == ref2
+#else
+
+type Socket = Posix.Socket
+
+#endif
 
 {-# DEPRECATED fdSocket "Use withFdSocket or unsafeFdSocket instead" #-}
 -- | Currently, this is an alias of `unsafeFdSocket`.
@@ -144,7 +153,11 @@ fdSocket = unsafeFdSocket
 --
 --   A safer option is to use 'withFdSocket' instead.
 unsafeFdSocket :: Socket -> IO CInt
-unsafeFdSocket (Socket ref _) = readIORef ref
+#if defined(mingw32_HOST_OS)
+unsafeFdSocket = eitherSocket Posix.unsafeFdSocket Win.unsafeFdSocket
+#else
+unsafeFdSocket = Posix.unsafeFdSocket
+#endif
 
 -- | Ensure that the given 'Socket' stays alive (i.e. not garbage-collected)
 --   at the given place in the sequence of IO actions. This function can be
@@ -155,15 +168,11 @@ unsafeFdSocket (Socket ref _) = readIORef ref
 -- > -- using fd with blocking operations such as accept(2)
 -- > touchSocket sock
 touchSocket :: Socket -> IO ()
-touchSocket (Socket ref _) = touch ref
-
-touch :: IORef a -> IO ()
-touch (IORef (STRef mutVar)) =
-  -- Thanks to a GHC issue, this touch# may not be quite guaranteed
-  -- to work. There's talk of replacing the touch# primop with one
-  -- that works better with the optimizer. But this seems to be the
-  -- "right" way to do it for now.
-  IO $ \s -> (## touch## mutVar s, () ##)
+#if defined(mingw32_HOST_OS)
+touchSocket = eitherSocket Posix.touchSocket Win.touchSocket
+#else
+touchSocket = Posix.touchSocket
+#endif
 
 -- | Get a file descriptor from a 'Socket'. The socket will never
 -- be closed automatically before @withFdSocket@ completes, but
@@ -176,15 +185,11 @@ touch (IORef (STRef mutVar)) =
 --
 -- Since: 3.1.0.0
 withFdSocket :: Socket -> (CInt -> IO r) -> IO r
-withFdSocket (Socket ref _) f = do
-  fd <- readIORef ref
-  -- Should we throw an exception if the socket is already invalid?
-  -- That will catch some mistakes but certainly not all.
-
-  r <- f fd
-
-  touch ref
-  return r
+#if defined(mingw32_HOST_OS)
+withFdSocket = eitherSocket Posix.withFdSocket Win.withFdSocket
+#else
+withFdSocket = Posix.withFdSocket
+#endif
 
 -- | Socket is closed and a duplicated file descriptor is returned.
 --   The duplicated descriptor is no longer subject to the possibility
@@ -192,51 +197,19 @@ withFdSocket (Socket ref _) f = do
 --   now the caller's responsibility to ultimately close the
 --   duplicated file descriptor.
 socketToFd :: Socket -> IO CInt
-socketToFd s = do
 #if defined(mingw32_HOST_OS)
-    fd <- unsafeFdSocket s
-    fd2 <- c_wsaDuplicate fd
-    -- FIXME: throw error no if -1
-    close s
-    return fd2
-
-foreign import ccall unsafe "wsaDuplicate"
-   c_wsaDuplicate :: CInt -> IO CInt
+socketToFd = eitherSocket Posix.socketToFd Win.socketToFd
 #else
-    fd <- unsafeFdSocket s
-    -- FIXME: throw error no if -1
-    fd2 <- c_dup fd
-    close s
-    return fd2
-
-foreign import ccall unsafe "dup"
-   c_dup :: CInt -> IO CInt
+socketToFd = Posix.socketToFd
 #endif
 
--- | Creating a socket from a file descriptor.
+-- | Create a socket from a file descriptor.
 mkSocket :: CInt -> IO Socket
-mkSocket fd = do
-    ref <- newIORef fd
-    let s = Socket ref fd
-    void $ mkWeakIORef ref $ close s
-    return s
-
-invalidSocket :: CInt
 #if defined(mingw32_HOST_OS)
-invalidSocket = #const INVALID_SOCKET
+mkSocket fd = (Socket . Left) <$> Posix.mkSocket fd
 #else
-invalidSocket = -1
+mkSocket = Posix.mkSocket
 #endif
-
-invalidateSocket ::
-      Socket
-   -> (CInt -> IO a)
-   -> (CInt -> IO a)
-   -> IO a
-invalidateSocket (Socket ref _) errorAction normalAction = do
-    oldfd <- atomicModifyIORef' ref $ \cur -> (invalidSocket, cur)
-    if oldfd == invalidSocket then errorAction oldfd else normalAction oldfd
-
 -----------------------------------------------------------------------------
 
 -- | Close the socket. This function does not throw exceptions even if
@@ -246,39 +219,20 @@ invalidateSocket (Socket ref _) errorAction normalAction = do
 --   the other use 'close', unexpected behavior may happen.
 --   For more information, please refer to the documentation of 'unsafeFdSocket'.
 close :: Socket -> IO ()
-close s = invalidateSocket s (\_ -> return ()) $ \oldfd -> do
-    -- closeFdWith avoids the deadlock of IO manager.
-    closeFdWith closeFd (toFd oldfd)
-  where
-    toFd :: CInt -> Fd
-    toFd = fromIntegral
-    -- closeFd ignores the return value of c_close and
-    -- does not throw exceptions
-    closeFd :: Fd -> IO ()
-    closeFd = void . c_close . fromIntegral
+#if defined(mingw32_HOST_OS)
+close = eitherSocket Posix.close Win.close
+#else
+close = Posix.close
+#endif
 
 -- | Close the socket. This function throws exceptions if
 --   the underlying system call returns errors.
 close' :: Socket -> IO ()
-close' s = invalidateSocket s (\_ -> return ()) $ \oldfd -> do
-    -- closeFdWith avoids the deadlock of IO manager.
-    closeFdWith closeFd (toFd oldfd)
-  where
-    toFd :: CInt -> Fd
-    toFd = fromIntegral
-    closeFd :: Fd -> IO ()
-    closeFd fd = do
-        ret <- c_close $ fromIntegral fd
-        when (ret == -1) $ throwErrno "Network.Socket.close'"
-
 #if defined(mingw32_HOST_OS)
-foreign import CALLCONV unsafe "closesocket"
-  c_close :: CInt -> IO CInt
+close' = eitherSocket Posix.close' Win.close'
 #else
-foreign import ccall unsafe "close"
-  c_close :: CInt -> IO CInt
+close' = Posix.close'
 #endif
-
 -----------------------------------------------------------------------------
 
 -- | Protocol number.

--- a/Network/Socket/Types/Posix.hsc
+++ b/Network/Socket/Types/Posix.hsc
@@ -1,0 +1,151 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+#include "HsNet.h"
+##include "HsNetDef.h"
+
+module Network.Socket.Types.Posix (
+    -- * Socket type
+      Socket
+    , withFdSocket
+    , unsafeFdSocket
+    , touchSocket
+    , socketToFd
+    , mkSocket
+    , invalidateSocket
+    , close
+    , close'
+    , c_close
+    ) where
+
+import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef', mkWeakIORef)
+import Foreign.C.Error (throwErrno)
+import GHC.Conc (closeFdWith)
+import System.Posix.Types (Fd)
+import GHC.Exts (touch##)
+import GHC.IORef (IORef (..))
+import GHC.STRef (STRef (..))
+import GHC.IO (IO (..))
+
+import Network.Socket.Imports
+
+-----------------------------------------------------------------------------
+
+-- | Basic type for a socket.
+data Socket = Socket (IORef CInt) CInt {- for Show -}
+
+instance Show Socket where
+    show (Socket _ ofd) = "<socket: " ++ show ofd ++ ">"
+
+instance Eq Socket where
+    Socket ref1 _ == Socket ref2 _ = ref1 == ref2
+
+unsafeFdSocket :: Socket -> IO CInt
+unsafeFdSocket (Socket ref _) = readIORef ref
+
+touchSocket :: Socket -> IO ()
+touchSocket (Socket ref _) = touch ref
+
+touch :: IORef a -> IO ()
+touch (IORef (STRef mutVar)) =
+  -- Thanks to a GHC issue, this touch# may not be quite guaranteed
+  -- to work. There's talk of replacing the touch# primop with one
+  -- that works better with the optimizer. But this seems to be the
+  -- "right" way to do it for now.
+  IO $ \s -> (## touch## mutVar s, () ##)
+
+
+withFdSocket :: Socket -> (CInt -> IO r) -> IO r
+withFdSocket (Socket ref _) f = do
+  fd <- readIORef ref
+  -- Should we throw an exception if the socket is already invalid?
+  -- That will catch some mistakes but certainly not all.
+
+  r <- f fd
+
+  touch ref
+  return r
+
+socketToFd :: Socket -> IO CInt
+socketToFd s = do
+#if defined(mingw32_HOST_OS)
+    fd <- unsafeFdSocket s
+    fd2 <- c_wsaDuplicate fd
+    -- FIXME: throw error no if -1
+    close s
+    return fd2
+
+foreign import ccall unsafe "wsaDuplicate"
+   c_wsaDuplicate :: CInt -> IO CInt
+#else
+    fd <- unsafeFdSocket s
+    -- FIXME: throw error no if -1
+    fd2 <- c_dup fd
+    close s
+    return fd2
+
+foreign import ccall unsafe "dup"
+   c_dup :: CInt -> IO CInt
+#endif
+
+mkSocket :: CInt -> IO Socket
+mkSocket fd = do
+    ref <- newIORef fd
+    let s = Socket ref fd
+    void $ mkWeakIORef ref $ close s
+    return s
+
+invalidSocket :: CInt
+#if defined(mingw32_HOST_OS)
+invalidSocket = #const INVALID_SOCKET
+#else
+invalidSocket = -1
+#endif
+
+invalidateSocket ::
+      Socket
+   -> (CInt -> IO a)
+   -> (CInt -> IO a)
+   -> IO a
+invalidateSocket (Socket ref _) errorAction normalAction = do
+    oldfd <- atomicModifyIORef' ref $ \cur -> (invalidSocket, cur)
+    if oldfd == invalidSocket then errorAction oldfd else normalAction oldfd
+
+close :: Socket -> IO ()
+close s = invalidateSocket s (\_ -> return ()) $ \oldfd -> do
+    -- closeFdWith avoids the deadlock of IO manager.
+    closeFdWith closeFd (toFd oldfd)
+  where
+    toFd :: CInt -> Fd
+    toFd = fromIntegral
+    -- closeFd ignores the return value of c_close and
+    -- does not throw exceptions
+    closeFd :: Fd -> IO ()
+    closeFd = void . c_close . fromIntegral
+
+close' :: Socket -> IO ()
+close' s = invalidateSocket s (\_ -> return ()) $ \oldfd -> do
+    -- closeFdWith avoids the deadlock of IO manager.
+    closeFdWith closeFd (toFd oldfd)
+  where
+    toFd :: CInt -> Fd
+    toFd = fromIntegral
+    closeFd :: Fd -> IO ()
+    closeFd fd = do
+        ret <- c_close $ fromIntegral fd
+        when (ret == -1) $ throwErrno "Network.Socket.close'"
+
+#if defined(mingw32_HOST_OS)
+foreign import CALLCONV unsafe "closesocket"
+  c_close :: CInt -> IO CInt
+#else
+foreign import ccall unsafe "close"
+  c_close :: CInt -> IO CInt
+#endif

--- a/Network/Socket/Types/WinIO.hsc
+++ b/Network/Socket/Types/WinIO.hsc
@@ -1,0 +1,130 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+##include "HsNetDef.h"
+#include "HsNet.h"
+
+module Network.Socket.Types.WinIO (
+    -- * Socket type
+      Socket
+    , SOCKET
+    , invalidSocket
+    , withSOCKET
+    , withFdSocket
+    , unsafeFdSocket
+    , touchSocket
+    , socketToFd
+    , mkSocket
+    , invalidateSocket
+    , close
+    , close'
+    , c_close
+    ) where
+
+import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef', mkWeakIORef)
+import GHC.Exts (touch##)
+import GHC.IORef (IORef (..))
+import GHC.STRef (STRef (..))
+import GHC.IO (IO (..))
+import GHC.Windows
+
+import Network.Socket.Imports
+
+-----------------------------------------------------------------------------
+type SOCKET = HANDLE
+
+-- | Basic type for a socket.
+data Socket = Socket (IORef SOCKET) SOCKET {- for Show -}
+
+instance Show Socket where
+    show (Socket _ ofd) = "<socket: " ++ show ofd ++ ">"
+
+instance Eq Socket where
+    Socket ref1 _ == Socket ref2 _ = ref1 == ref2
+
+-- ew
+winsockToInt :: SOCKET -> CInt
+winsockToInt = fromIntegral . ptrToIntPtr
+
+unsafeSOCKET :: Socket -> IO SOCKET
+unsafeSOCKET (Socket ref _) = readIORef ref
+
+unsafeFdSocket :: Socket -> IO CInt
+unsafeFdSocket s = winsockToInt <$> unsafeSOCKET s
+
+touchSocket :: Socket -> IO ()
+touchSocket (Socket ref _) = touch ref
+
+touch :: IORef a -> IO ()
+touch (IORef (STRef mutVar)) =
+  -- See Types.Posix
+  IO $ \s -> (## touch## mutVar s, () ##)
+
+withFdSocket :: Socket -> (CInt -> IO r) -> IO r
+withFdSocket (Socket ref _) f = do
+  s <- readIORef ref
+  -- Should we throw an exception if the socket is already invalid?
+  -- That will catch some mistakes but certainly not all.
+
+  r <- f $ winsockToInt s
+
+  touch ref
+  return r
+
+withSOCKET :: Socket -> (SOCKET -> IO r) -> IO r
+withSOCKET (Socket ref _ ) f = do
+    s <- readIORef ref
+    r <- f s
+    touch ref
+    return r
+
+socketToFd :: Socket -> IO CInt
+socketToFd s = do
+    sock <- unsafeSOCKET s
+    sock2 <- c_wsaDuplicate sock
+    -- FIXME: throw error no if -1
+    close s
+    return $ winsockToInt sock2
+
+foreign import ccall unsafe "wsaDuplicate"
+   c_wsaDuplicate :: SOCKET -> IO SOCKET
+
+mkSocket :: SOCKET -> IO Socket
+mkSocket sock = do
+    ref <- newIORef sock
+    let s = Socket ref sock
+    void $ mkWeakIORef ref $ close s
+    return s
+
+invalidSocket :: SOCKET
+invalidSocket = intPtrToPtr $ #const INVALID_SOCKET
+{-# INLINE invalidSocket #-}
+
+invalidateSocket ::
+      Socket
+   -> (SOCKET -> IO a)
+   -> (SOCKET -> IO a)
+   -> IO a
+invalidateSocket (Socket ref _) errorAction normalAction = do
+    oldsock <- atomicModifyIORef' ref $ \cur -> (invalidSocket, cur)
+    if oldsock == invalidSocket then errorAction oldsock else normalAction oldsock
+
+close :: Socket -> IO ()
+close s = invalidateSocket s (\_ -> return ()) $ \oldsock ->
+    -- closeFdWith avoids the deadlock of IO manager.
+    void $ c_close oldsock
+
+close' :: Socket -> IO ()
+close' s = invalidateSocket s (\_ -> return ()) $ \oldfd -> do
+    -- IOCP doesn't give us the same deadlock opportunities... right?
+    failIf_ (/= 0) "Network.Socket.close'" $ c_close oldfd
+
+foreign import ccall unsafe "closesocket"
+  c_close :: SOCKET -> IO CInt

--- a/Network/Socket/Win32/Load.hs
+++ b/Network/Socket/Win32/Load.hs
@@ -1,0 +1,39 @@
+module Network.Socket.Win32.Load (
+    Loaded(..),
+    loadExtensionFunction,
+) where
+
+import Control.Concurrent.STM
+import GHC.Windows
+import Network.Socket.Imports
+import Network.Socket.Internal (throwSocketError)
+import Network.Socket.Types.WinIO (SOCKET)
+
+data Loaded a = Unloaded | Loading | Loaded a
+
+-- | Load a Winsock extension function once, caching the result in a TVar.
+-- The C loader uses WSAIoctl with SIO_GET_EXTENSION_FUNCTION_POINTER.
+loadExtensionFunction
+    :: TVar (Loaded a)
+    -> (SOCKET -> IO (FunPtr a))
+    -> (FunPtr a -> a)
+    -> String
+    -> SOCKET -> IO a
+loadExtensionFunction var load mk fname s = do
+    mfn <- atomically $ do
+        c <- readTVar var
+        case c of
+            Unloaded -> do
+                writeTVar var Loading
+                pure Nothing
+            Loading -> retry
+            Loaded l -> pure $ Just l
+    case mfn of
+        Nothing -> do
+            fp <- load s
+            when (fp == nullFunPtr) $
+                throwSocketError ("Network.Socket: can't load " <> fname)
+            let fn = mk fp
+            atomically $ writeTVar var $ Loaded fn
+            pure fn
+        Just fn -> pure fn

--- a/cbits/winSock.c
+++ b/cbits/winSock.c
@@ -1,0 +1,81 @@
+#include "HsNet.h"
+
+LPFN_CONNECTEX loadConnectEx(SOCKET sock)
+{
+    GUID guid = WSAID_CONNECTEX;
+    LPFN_CONNECTEX cex = NULL;
+    DWORD bytes;
+
+    WSAIoctl(sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &guid, sizeof(guid),
+            &cex, sizeof(cex),
+            &bytes, NULL, NULL);
+    return cex;
+}
+
+LPFN_ACCEPTEX loadAcceptEx(SOCKET sock)
+{
+    GUID guid = WSAID_ACCEPTEX;
+    LPFN_ACCEPTEX fn = NULL;
+    DWORD bytes;
+
+    WSAIoctl(sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &guid, sizeof(guid),
+            &fn, sizeof(fn),
+            &bytes, NULL, NULL);
+    return fn;
+}
+
+LPFN_GETACCEPTEXSOCKADDRS loadGetAcceptExSockaddrs(SOCKET sock)
+{
+    GUID guid = WSAID_GETACCEPTEXSOCKADDRS;
+    LPFN_GETACCEPTEXSOCKADDRS fn = NULL;
+    DWORD bytes;
+
+    WSAIoctl(sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &guid, sizeof(guid),
+            &fn, sizeof(fn),
+            &bytes, NULL, NULL);
+    return fn;
+}
+
+LPFN_WSASENDMSG loadWSASendMsg(SOCKET sock)
+{
+    GUID guid = WSAID_WSASENDMSG;
+    LPFN_WSASENDMSG fn = NULL;
+    DWORD bytes;
+
+    WSAIoctl(sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &guid, sizeof(guid),
+            &fn, sizeof(fn),
+            &bytes, NULL, NULL);
+    return fn;
+}
+
+LPFN_WSARECVMSG loadWSARecvMsg(SOCKET sock)
+{
+    GUID guid = WSAID_WSARECVMSG;
+    LPFN_WSARECVMSG fn = NULL;
+    DWORD bytes;
+
+    WSAIoctl(sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &guid, sizeof(guid),
+            &fn, sizeof(fn),
+            &bytes, NULL, NULL);
+    return fn;
+}
+
+/// Create an unbound socket matching the given listen socket's
+/// address family and type. AcceptEx requires a pre-created accept socket.
+SOCKET createPeerSocket(SOCKET listenSock)
+{
+    struct sockaddr_storage addr;
+    int addrLen = sizeof(addr);
+    if (getsockname(listenSock, (struct sockaddr*)&addr, &addrLen) != 0)
+        return INVALID_SOCKET;
+    int type;
+    int typeLen = sizeof(type);
+    if (getsockopt(listenSock, SOL_SOCKET, SO_TYPE, (char*)&type, &typeLen) != 0)
+        return INVALID_SOCKET;
+    return socket(addr.ss_family, type, 0);
+}

--- a/network.cabal
+++ b/network.cabal
@@ -103,6 +103,7 @@ library
 
     other-modules:
         Network.Socket.Buffer
+        Network.Socket.Buffer.Posix
         Network.Socket.ByteString.IO
         Network.Socket.ByteString.Internal
         Network.Socket.Cbits
@@ -114,12 +115,15 @@ library
         Network.Socket.Info
         Network.Socket.Name
         Network.Socket.Options
+        Network.Socket.Options.Posix
         Network.Socket.ReadShow
         Network.Socket.STM
         Network.Socket.Shutdown
         Network.Socket.SockAddr
         Network.Socket.Syscall
+        Network.Socket.Syscall.Posix
         Network.Socket.Types
+        Network.Socket.Types.Posix
         Network.Socket.Unix
 
     default-language: Haskell2010
@@ -155,12 +159,18 @@ library
         c-sources:
             cbits/initWinSock.c
             cbits/winSockErr.c
+            cbits/winSock.c
             cbits/asyncAccept.c
 
         other-modules:
+            Network.Socket.Buffer.WinIO
             Network.Socket.ByteString.Lazy.Windows
+            Network.Socket.Options.WinIO
+            Network.Socket.Syscall.WinIO
+            Network.Socket.Types.WinIO
             Network.Socket.Win32.Cmsg
             Network.Socket.Win32.CmsgHdr
+            Network.Socket.Win32.Load
             Network.Socket.Win32.WSABuf
             Network.Socket.Win32.MsgHdr
 
@@ -168,6 +178,7 @@ library
             ws2_32
             iphlpapi
             mswsock
+            ntdll
 
         if impl(ghc >=7.10)
             cpp-options: -D_WIN32_WINNT=0x0600
@@ -191,7 +202,7 @@ test-suite spec
         Network.Socket.ByteString.LazySpec
 
     default-language: Haskell2010
-    ghc-options:      -Wall -threaded
+    ghc-options:      -Wall -threaded "-with-rtsopts=-N --io-manager=native"
     build-depends:
         base,
         bytestring,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: lts-24.6
 packages:
 - '.'
 nix:


### PR DESCRIPTION
Another attempt at #364, #509, #602 with the following design choices:

1. On Windows systems, `Socket` becomes an `Either` over the existing "Posix" socket implemntation and a Windows equivalent using its `SOCKET` type.

2. On Posix systems, or without enabling the WinIO manager with `--io-manager=native`, the current behavior is unchanged.

3. *With* the WinIO manager, a greenfield implementation around the relevant syscalls is used, using IO Completion Ports (AKA "Overlapped IO") through GHC's `withOverlapped`

For the places we need to mux between the two
(`Network.Socket.Syscall`, `Network.Socket.Buffer`, etc.) the existing implementation is moved into a `Posix.hsc` and the WinIO one is defined in `WinIO.hsc`.

There's certainly some cleanup and style improvements that could be done, but it passes all existing tests, and hopefully provides a clean separation between the existing code (which can stay unchanged) and direct use of Windows syscalls through `withOverlapped`.