### PR TITLE
Multicast support

### DIFF
--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -170,7 +170,12 @@ module Network.Socket (
         DontFragment,
         RecvIPv6HopLimit,
         RecvIPv6TClass,
-        RecvIPv6PktInfo
+        RecvIPv6PktInfo,
+        MulticastIF,
+        MulticastTTL,
+        MulticastLoop,
+        AddMembership,
+        DropMembership
     ),
     isSupportedSocketOption,
     whenSupported,

--- a/Network/Socket.hs
+++ b/Network/Socket.hs
@@ -405,6 +405,9 @@ module Network.Socket (
 
     -- * Deprecated
     withSocketsDo,
+
+    -- * Multicast Group
+    MulticastGroup (..),
 ) where
 
 import Network.Socket.Buffer hiding (

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -18,6 +18,7 @@ module Network.Socket.Options (
                 ,UseLoopBack,UserTimeout,IPv6Only
                 ,RecvIPv4TTL,RecvIPv4TOS,RecvIPv4PktInfo,DontFragment
                 ,RecvIPv6HopLimit,RecvIPv6TClass,RecvIPv6PktInfo
+                ,MulticastIF,MulticastTTL,MulticastLoop,AddMembership,DropMembership
                 ,CustomSockOpt)
   , isSupportedSocketOption
   , whenSupported

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -397,7 +397,7 @@ pattern RecvIPv6PktInfo = SockOpt (-1) (-1)
 #endif
 #endif // HAVE_DECL_IPPROTO_IPV6
 
-
+-- | Multicast interface.
 #ifdef IP_MULTICAST_IF
 pattern MulticastIF :: SocketOption
 pattern MulticastIF = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_IF)
@@ -405,8 +405,7 @@ pattern MulticastIF = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_IF)
 pattern MulticastIF :: SocketOption
 pattern MulticastIF = SockOpt (-1) (-1)
 #endif
-
-
+-- | Multicast TTL.
 #ifdef IP_MULTICAST_TTL
 pattern MulticastTTL :: SocketOption
 pattern MulticastTTL = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_TTL)
@@ -414,7 +413,7 @@ pattern MulticastTTL = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_TTL)
 pattern MulticastTTL :: SocketOption
 pattern MulticastTTL = SockOpt (-1) (-1)
 #endif
-
+-- | Multicast loopback.
 #ifdef IP_MULTICAST_LOOP
 pattern MulticastLoop :: SocketOption
 pattern MulticastLoop = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_LOOP)
@@ -422,7 +421,7 @@ pattern MulticastLoop = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_LOOP)
 pattern MulticastLoop :: SocketOption
 pattern MulticastLoop = SockOpt (-1) (-1)
 #endif
-
+-- | Add membership.
 #ifdef IP_ADD_MEMBERSHIP
 pattern AddMembership :: SocketOption
 pattern AddMembership = SockOpt (#const IPPROTO_IP) (#const IP_ADD_MEMBERSHIP)
@@ -430,7 +429,7 @@ pattern AddMembership = SockOpt (#const IPPROTO_IP) (#const IP_ADD_MEMBERSHIP)
 pattern AddMembership :: SocketOption
 pattern AddMembership = SockOpt (-1) (-1)
 #endif
-
+-- | Drop membership.
 #ifdef IP_DROP_MEMBERSHIP
 pattern DropMembership :: SocketOption
 pattern DropMembership = SockOpt (#const IPPROTO_IP) (#const IP_DROP_MEMBERSHIP)

--- a/Network/Socket/Options.hsc
+++ b/Network/Socket/Options.hsc
@@ -397,6 +397,49 @@ pattern RecvIPv6PktInfo = SockOpt (-1) (-1)
 #endif
 #endif // HAVE_DECL_IPPROTO_IPV6
 
+
+#ifdef IP_MULTICAST_IF
+pattern MulticastIF :: SocketOption
+pattern MulticastIF = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_IF)
+#else
+pattern MulticastIF :: SocketOption
+pattern MulticastIF = SockOpt (-1) (-1)
+#endif
+
+
+#ifdef IP_MULTICAST_TTL
+pattern MulticastTTL :: SocketOption
+pattern MulticastTTL = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_TTL)
+#else
+pattern MulticastTTL :: SocketOption
+pattern MulticastTTL = SockOpt (-1) (-1)
+#endif
+
+#ifdef IP_MULTICAST_LOOP
+pattern MulticastLoop :: SocketOption
+pattern MulticastLoop = SockOpt (#const IPPROTO_IP) (#const IP_MULTICAST_LOOP)
+#else
+pattern MulticastLoop :: SocketOption
+pattern MulticastLoop = SockOpt (-1) (-1)
+#endif
+
+#ifdef IP_ADD_MEMBERSHIP
+pattern AddMembership :: SocketOption
+pattern AddMembership = SockOpt (#const IPPROTO_IP) (#const IP_ADD_MEMBERSHIP)
+#else
+pattern AddMembership :: SocketOption
+pattern AddMembership = SockOpt (-1) (-1)
+#endif
+
+#ifdef IP_DROP_MEMBERSHIP
+pattern DropMembership :: SocketOption
+pattern DropMembership = SockOpt (#const IPPROTO_IP) (#const IP_DROP_MEMBERSHIP)
+#else
+pattern DropMembership :: SocketOption
+pattern DropMembership = SockOpt (-1) (-1)
+#endif
+
+
 pattern CustomSockOpt :: (CInt, CInt) -> SocketOption
 pattern CustomSockOpt xy <- ((\(SockOpt x y) -> (x, y)) -> xy)
   where

--- a/Network/Socket/Types.hsc
+++ b/Network/Socket/Types.hsc
@@ -85,6 +85,9 @@ module Network.Socket.Types (
     , htonl
     , ntohl
     , In6Addr(..)
+
+    -- * Multicast Group
+    , MulticastGroup(..)
     ) where
 
 import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef', mkWeakIORef, modifyIORef')
@@ -1528,3 +1531,27 @@ foreign import ccall unsafe "string.h" memset :: Ptr a -> CInt -> CSize -> IO ()
 -- | Zero a structure.
 zeroMemory :: Ptr a -> CSize -> IO ()
 zeroMemory dest nbytes = memset dest 0 (fromIntegral nbytes)
+
+
+------------------------------------------------------------------------
+-- Multicast Group
+
+data MulticastGroup = MulticastGroup
+    { groupAddress :: HostAddress
+    , localAddress :: Maybe HostAddress
+    } deriving (Show, Eq)
+
+instance Storable MulticastGroup where
+    sizeOf ~_ = #size struct ip_mreq
+    alignment ~_ = #alignment struct ip_mreq
+    peek p = do
+        g <- (#peek struct ip_mreq, imr_multiaddr) p
+        l <- (#peek struct ip_mreq, imr_interface) p
+        pure . MulticastGroup g $ case l of
+            0 -> Nothing
+            loc -> Just loc
+    poke p (MulticastGroup g l) = do
+        (#poke struct ip_mreq, imr_multiaddr) p g
+        (#poke struct ip_mreq, imr_interface) p (case l of
+            Nothing -> 0
+            Just loc -> loc)


### PR DESCRIPTION
Add multicast. 

Tested on Linux, Windows, Mac OS.

Example:

```Haskell
module Discovery.Scanner where

import Control.Exception
import Control.Monad
import Data.List.NonEmpty qualified as NE
import Network.Socket
import Network.Socket.ByteString

runScanner :: HostName -> HostName -> ServiceName -> IO ()
runScanner host group port = do
    host' <- resolve host
    group' <- resolve group
    let multicast = MulticastGroup (hostAddress group'.addrAddress) Nothing
    bracket (socket AF_INET Datagram defaultProtocol) close \sock -> do
        bind sock host'.addrAddress
        setSockOpt sock AddMembership multicast
        forever do
            msg <- recv sock 1024
            print msg
  where
    resolve addr = NE.head <$> getAddrInfo Nothing (Just addr) (Just port)

hostAddress :: SockAddr -> HostAddress
hostAddress (SockAddrInet _ addr) = addr
hostAddress _ = error "Unsupported socket address"
```

```Haskell
module Discovery.Annoncer where

import Control.Concurrent
import Control.Exception
import Control.Monad
import Data.List.NonEmpty qualified as NE
import Network.Socket
import Network.Socket.ByteString

runAnnoncer :: HostName -> ServiceName -> IO ()
runAnnoncer group port = do
    group' <- resolve group
    bracket (socket AF_INET Datagram defaultProtocol) close \sock -> do
        forever do
            sendAllTo sock "hello" group'.addrAddress
            threadDelay 1_000_000
  where
    resolve addr = NE.head <$> getAddrInfo Nothing (Just addr) (Just port)
```

```Haskell
import Control.Concurrent.Async
import Control.Monad
import Discovery.Annoncer
import Discovery.Scanner

main :: IO ()
main = void $ concurrently
    do runAnnoncer "239.0.0.1" "2026"
    do runScanner "0.0.0.0" "239.0.0.1" "2026"    
```

