### PR TITLE
Fix typo for `WSAEACCES` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Exporting recvBufNoWait.
 * Support for getHostName
   [#621](https://github.com/haskell/network/pull/621)
+* Fixing the misspelled WSAEACCES error description on Windows.
+  [#622](https://github.com/haskell/network/pull/622)
 
 ## Version 3.2.8.0
 

--- a/cbits/winSockErr.c
+++ b/cbits/winSockErr.c
@@ -14,7 +14,7 @@ getWSErrorDescr(int err)
   switch (err) {
   case WSAEINTR:  return "Interrupted function call (WSAEINTR)";
   case WSAEBADF:  return "bad socket descriptor (WSAEBADF)";
-  case WSAEACCES: return "Permission denied (WSAEACCESS)";
+  case WSAEACCES: return "Permission denied (WSAEACCES)";
   case WSAEFAULT: return "Bad address (WSAEFAULT)";
   case WSAEINVAL: return "Invalid argument (WSAEINVAL)";
   case WSAEMFILE: return "Too many open files (WSAEMFILE)";


### PR DESCRIPTION
Fixes https://github.com/haskell/network/issues/623

I wasn't sure whether this should qualify as a breaking change. The typo is not documented behavior, but if someone depended on it, their code will break.